### PR TITLE
TTL Script fails at 'sendfile'

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -49,6 +49,7 @@
         <li>Fixed <a href="../macro/command/settitle.html">settitle</a>, <a href="../macro/command/gettitle.html">gettitle</a>, <a href="../macro/command/loadkeymap.html">loadkeymap</a> to handel string in Unicode.
         <li>Currently, Tera Term handle local title strings in ANSI strings. Characters that cannot be converted are replaced by "?".</li>
       </ul>
+      <li>MACRO: fixed <a href="../macro/command/sendfile.html">sendfile</a> command stuck even if transmission is completed to send.</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -49,6 +49,7 @@
         <li><a href="../macro/command/settitle.html">settitle</a>, <a href="../macro/command/gettitle.html">gettitle</a>, <a href="../macro/command/loadkeymap.html">loadkeymap</a> が文字列をUnicodeとして扱うよう修正。
         <li>現在、Tera Term 内部ではローカルタイトル文字列をANSI文字列で持っている。変換できない文字は "?" に置き換えられる。</li>
       </ul>
+      <li><a href="../macro/command/sendfile.html">sendfile</a> マクロコマンドで送信完了してもコマンドが終了しない問題を修正した。</li>
     </ul>
   </li>
 

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -387,6 +387,15 @@ static WORD HexStr2Word(PCHAR Str)
 	return w;
 }
 
+/**
+ *	送信完了コールバック
+ */
+static void SendCallback(void *callback_data)
+{
+	(void)callback_data;
+	EndDdeCmnd(0);
+}
+
 static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 {
 	char Command[MaxStrLen + 1];
@@ -658,7 +667,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		BOOL r = FileSendStart(ParamFileNameW, ParamBinaryFlag);
 #else
 		// 5 で追加した方法で送信
-		BOOL r = SendMemSendFile(ParamFileNameW, ParamBinaryFlag, 0, 0, 0);
+		BOOL r = SendMemSendFile2(ParamFileNameW, ParamBinaryFlag, 0, 0, 0, SendCallback, NULL);
 #endif
 		free(ParamFileNameW);
 		if (r) {


### PR DESCRIPTION
- 送信終了時に EndDdeCmnd(0) をコールするよう修正
- #19