### PR TITLE
VS2022のプロジェクトファイルの参照誤りを修正

### DIFF
--- a/cygwin/cyglaunch/cyglaunch.v17.vcxproj
+++ b/cygwin/cyglaunch/cyglaunch.v17.vcxproj
@@ -95,7 +95,7 @@
     <ClCompile Include="cyglaunch.c" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\cyglib\cyglib.v16.vcxproj">
+    <ProjectReference Include="..\cyglib\cyglib.v17.vcxproj">
       <Project>{a171f48c-bfb2-4766-97c3-9b8b7be9d548}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/teraterm/keycode/keycode.v17.vcxproj
+++ b/teraterm/keycode/keycode.v17.vcxproj
@@ -133,10 +133,10 @@
     <ClInclude Include="kc_res.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common_static.v16.vcxproj">
+    <ProjectReference Include="..\common\common_static.v17.vcxproj">
       <Project>{ac42387d-23ec-45db-81f9-8933c7efa52a}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/teraterm/teraterm/ttermpro.v17.vcxproj
+++ b/teraterm/teraterm/ttermpro.v17.vcxproj
@@ -312,18 +312,18 @@
     <ClInclude Include="unicode.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common_static.v16.vcxproj">
+    <ProjectReference Include="..\common\common_static.v17.vcxproj">
       <Project>{ac42387d-23ec-45db-81f9-8933c7efa52a}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ttpmacro\ttpmacro.v16.vcxproj">
+    <ProjectReference Include="..\ttpmacro\ttpmacro.v17.vcxproj">
       <Project>{ba519362-a2c2-4b1a-905b-f00791f9038a}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ttptek\ttptek.v16.vcxproj">
+    <ProjectReference Include="..\ttptek\ttptek.v17.vcxproj">
       <Project>{6d08053b-1c68-4a7e-8766-3553f5af010b}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/teraterm/ttpcmn/ttpcmn.v17.vcxproj
+++ b/teraterm/ttpcmn/ttpcmn.v17.vcxproj
@@ -163,7 +163,7 @@
     <ResourceCompile Include="ttpcmn-version.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common_static.v16.vcxproj">
+    <ProjectReference Include="..\common\common_static.v17.vcxproj">
       <Project>{ac42387d-23ec-45db-81f9-8933c7efa52a}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/teraterm/ttpmacro/ttpmacro.v17.vcxproj
+++ b/teraterm/ttpmacro/ttpmacro.v17.vcxproj
@@ -188,10 +188,10 @@
     <ResourceCompile Include="ttmacro_manifest.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common_static.v16.vcxproj">
+    <ProjectReference Include="..\common\common_static.v17.vcxproj">
       <Project>{ac42387d-23ec-45db-81f9-8933c7efa52a}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/teraterm/ttptek/ttptek.v17.vcxproj
+++ b/teraterm/ttptek/ttptek.v17.vcxproj
@@ -143,10 +143,10 @@
     <ResourceCompile Include="ttptek-version.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\common\common_static.v16.vcxproj">
+    <ProjectReference Include="..\common\common_static.v17.vcxproj">
       <Project>{ac42387d-23ec-45db-81f9-8933c7efa52a}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>


### PR DESCRIPTION
- VS2019のプロジェクトファイルに依存していた
- VS2022でビルドする時に2019(v142ビルドツール)をインストールしている必要があった