### PR TITLE
接続先が登録されていないとき、"(none)"が表示されるよう修正 #76

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -58,10 +58,11 @@
     </ul>
   </li>
 
-  <!-- li>Misc
+  <li>Misc
     <ul>
+      <li>Upgraded TeraTerm Menu to <a href="#ttmenu_1.19">1.19</a></li>
     </ul>
-  </li -->
+  </li>
 </ul>
 
 <h3 id="teraterm_5.1">2023.12.19 (Ver 5.1)</h3>
@@ -5303,9 +5304,23 @@ SYNOPSIS:
 
 <h2 id="ttmenu">TeraTerm Menu</h2>
 
+<h3 id="ttmenu_1.19">YYYY.MM.DD (Ver 1.19 not released)</h3>
+<ul class="history">
+      <li>When execution list is empty, "(none)" is not displayed correctly.</li>
+</ul>
+
 <h3 id="ttmenu_1.18">2023.12.19 (Ver 1.18)</h3>
 <ul class="history">
-      <li>Win32 API was changed to the Unicode version, and strings were changed to Unicode.
+      <li>Win32 API was changed to the Unicode version, and strings were changed to Unicode.</li>
+      <li>Removed upper limit of argument length of the program invoked from TeraTerm Menu.</li>
+      <li>Copy ini files to take over settings.</li>
+      <ul>
+        <li>If ttpmenu.ini exists in the same path as ttpmenu.exe and %APPDATA%\teraterm5\ttpmenu.ini does not exist.</li>
+      </ul>
+      <li>Support portable edition(when portable.ini exists in exe folder).</li>
+      <li>When %APPDATA%\teraterm5\ttpmenu.ini is 0byte, write UTF-16 LE BOM.</li>
+      <li>Removed upper limit of ttpmenu.ini file name length.</li>
+      <li>Display that settings is either registry or ini file in about dialog.</li>
 </ul>
 
 <h3 id="ttmenu_1.17">2023.10.15 (Ver 1.17)</h3>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -58,10 +58,11 @@
     </ul>
   </li>
 
-  <!-- li>その他
+  <li>その他
     <ul>
+      <li><a href="#ttmenu_1.19">TeraTerm Menu(1.19)</a>へ差し替えた。</li>
     </ul>
-  </li -->
+  </li>
 </ul>
 
 <h3 id="teraterm_5.1">2023.12.19 (Ver 5.1)</h3>
@@ -5314,9 +5315,24 @@
 
 <h2 id="ttmenu">TeraTerm Menu</h2>
 
+<h3 id="ttmenu_1.19">YYYY.MM.DD (Ver 1.19 not released)</h3>
+<ul class="history">
+      <li>接続先が登録されていないとき、"(none)"が正しく表示されないので修正した。</li>
+</ul>
+
 <h3 id="ttmenu_1.18">2023.12.19 (Ver 1.18)</h3>
 <ul class="history">
       <li>使用しているWin32 APIを Unicode版に変更、文字列をUnicodeに変更した。</li>
+      <li>TeraTerm Menuから起動するプログラムの引数長の上限をなくした。</li>
+      <li>従来の設定を引き継げるようiniファイルをコピーするようにした。</li>
+      <ul>
+        <li>ttpmenu.exeと同じパスの ttpmenu.ini が存在して
+          %APPDATA%\teraterm5\ttpmenu.ini が存在しない場合</li>
+      </ul>
+      <li>ポータブル版動作(exeフォルダにportable.iniが存在する)に対応した。</li>
+      <li>%APPDATA%\teraterm5\ttpmenu.ini が0byteの時、UTF-16 LE BOM を書き込むようにした。</li>
+      <li>ttpmenu.iniのファイル名長の上限をなくした。</li>
+      <li>バージョン表示に設定がレジストリ/iniのどちらかを表示するようにした。</li>
 </ul>
 
 <h3 id="ttmenu_1.17">2023.10.15 (Ver 1.17)</h3>

--- a/ttpmenu/readme.txt
+++ b/ttpmenu/readme.txt
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------------------
                                Tera Term支援ツール
-                           Tera Term Menu Version 1.18
+                           Tera Term Menu Version 1.19
 
                           (C) 2004- TeraTerm Project
                         https://teratermproject.github.io/
@@ -213,15 +213,21 @@ iniファイルはUnicode iniファイル(UTF-16 with LE BOM)の使用をおすすめします。
 --------------------------------------------------------------------------------
 9. 更新履歴
 
+TeraTerm Menu 1.19 (YYYY.MM.DD)
+
+・接続先が登録されていないとき、"(none)"が正しく表示されないので修正した。
+
 TeraTerm Menu 1.18 (2023.12.02)
 
-・内部文字列、使用APIなどをUnicodeに変更した。
-・引数の上限をなくした。
+・使用しているWin32 APIを Unicode版に変更、文字列をUnicodeに変更した。
+・TeraTerm Menuから起動するプログラムの引数長の上限をなくした。
 ・従来の設定を引き継げるようiniファイルをコピーするようにした。
   - ttpmenu.exeと同じパスの ttpmenu.ini が存在して
     %APPDATA%\teraterm5\ttpmenu.ini が存在しない場合
-・ポータブル版動作(exeフォルダにportable.iniが存在する)に対応
-・%APPDATA%\teraterm5\ttpmenu.ini が0byteの時、UTF-16 LE BOM を書き込むようにした
+・ポータブル版動作(exeフォルダにportable.iniが存在する)に対応した。
+・%APPDATA%\teraterm5\ttpmenu.ini が0byteの時、UTF-16 LE BOM を書き込むようにした。
+・ttpmenu.iniのファイル名長の上限をなくした。
+・バージョン表示に設定がレジストリ/iniのどちらかを表示するようにした。
 
 TeraTerm Menu 1.17 (2023.10.15)
 

--- a/ttpmenu/ttpmenu-version.h
+++ b/ttpmenu/ttpmenu-version.h
@@ -31,7 +31,7 @@
 #include "tt-version.h"
 
 #define TTPMENU_VERSION_MAJOR             1
-#define TTPMENU_VERSION_MINOR             18
+#define TTPMENU_VERSION_MINOR             19
 #define TTPMENU_VERSION_STR(sep)          TT_TOSTR(TTPMENU_VERSION_MAJOR) sep TT_TOSTR(TTPMENU_VERSION_MINOR)
 #define TTPMENU_RES_VERSION_STR           TTPMENU_VERSION_STR(", ") ", 0, 0"
 

--- a/ttpmenu/ttpmenu.cpp
+++ b/ttpmenu/ttpmenu.cpp
@@ -1407,7 +1407,7 @@ BOOL RedrawMenu(HWND hWnd)
 	}
 	if (dwValidCnt == 0) {
 		UTIL_get_lang_msgW("MENU_NOTRAY", uimsg, _countof(uimsg), STR_NOENTRY, UILanguageFileW);
-		::AppendMenu(g_hListMenu, MF_STRING | MF_GRAYED, ID_NOENTRY, (LPCTSTR) uimsg);
+		::AppendMenuW(g_hListMenu, MF_STRING | MF_GRAYED, ID_NOENTRY, uimsg);
 	}
 
 	return TRUE;


### PR DESCRIPTION
- 接続先が登録されていないとき、"(none)"が表示されるよう修正した。
  - "(" が表示されていた
- readme.txtに更新履歴を追記
- 改版履歴追記
- バージョン更新
  - 1.18 -> 1.19