### PR TITLE
文字が透過しない場合があったので修正

### DIFF
--- a/teraterm/common/compat_win.cpp
+++ b/teraterm/common/compat_win.cpp
@@ -191,6 +191,7 @@ static const APIInfo Lists_user32[] = {
 
 static const APIInfo Lists_msimg32[] = {
 	{ "AlphaBlend", (void **)&pAlphaBlend },
+	{ "TransparentBlt", (void **)&pTransparentBlt },
 	{},
 };
 

--- a/teraterm/teraterm/vtdisp.c
+++ b/teraterm/teraterm/vtdisp.c
@@ -2925,7 +2925,7 @@ void DrawStrW(HDC DC, HDC BGDC, const wchar_t *StrW, const char *cells, int len,
 			else {
 				SIZE size;
 				GetTextExtentPoint32W(DC, &StrW[i - zero_count], 1 + zero_count, &size);
-				if ((size.cx == Dx[i])) {
+				if ((size.cx == Dx[i]) || (size.cx == Dx[i] + 1)) {
 					wchar_count++;
 					cell_count += cells[i];
 				}


### PR DESCRIPTION
- TransparentBlt API を使用できるよう修正
- 文字描画時にフォントサイズが1pixel大きい場合、縮小せずに描画するようにした
