### PR TITLE
UTF-8m, UTF8m を削除 #63

### DIFF
--- a/TTXSamples/TTXKcodeChange/.editorconfig
+++ b/TTXSamples/TTXKcodeChange/.editorconfig
@@ -1,0 +1,2 @@
+[*.{cpp,c,h,cc}]
+indent_size = 8

--- a/TTXSamples/TTXKcodeChange/ReadMe-ja.txt
+++ b/TTXSamples/TTXKcodeChange/ReadMe-ja.txt
@@ -13,7 +13,7 @@ TTXKcodeChange -- 制御シーケンスで送受信漢字コードを変更出来るようにする
       KT  -- 送信漢字コード
              Valueとして SJIS, EUC, JIS, UTF8 を受け付けます。
       KR  -- 受信漢字コード
-             Valueとして SJIS, EUC, JIS, UTF8, UTF8m を受け付けます。
+             Valueとして SJIS, EUC, JIS, UTF8 を受け付けます。
 
   <OSC>5964;Pt<ST>
   <OSC>5964;Pt<BEL>

--- a/TTXSamples/TTXKcodeChange/TTXKcodeChange.c
+++ b/TTXSamples/TTXKcodeChange/TTXKcodeChange.c
@@ -216,8 +216,6 @@ void ParseInputStr(unsigned char *rstr, int rcount) {
 		  pvar->cv->KanjiCodeEcho = pvar->ts->KanjiCode = IdJIS;
 		else if (_stricmp(p, "UTF8") == 0 || _stricmp(p, "UTF-8") == 0)
 		  pvar->cv->KanjiCodeEcho = pvar->ts->KanjiCode = IdUTF8;
-		else if (_stricmp(p, "UTF8m") == 0 || _stricmp(p, "UTF-8m") == 0)
-		  pvar->cv->KanjiCodeEcho = pvar->ts->KanjiCode = IdUTF8;
 	      }
 	      p = p2;
 	    }

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -43,6 +43,7 @@
         <li>Host list is wider.</li>
       </ul>
       <li>MACRO: Dialog displayed using <a href="../macro/command/listbox.html">listbox</a> command can now be resized.</li>
+      <li>reomve UTF8m in <a href="../commandline/teraterm.html#kr">/KR</a>, <a href="../commandline/teraterm.html#kt">/KT</a> command line options.</li>
     </ul>
   </li>
 

--- a/doc/en/html/commandline/teraterm.html
+++ b/doc/en/html/commandline/teraterm.html
@@ -175,8 +175,7 @@ TTERMPRO [ &lt;host&gt;[[:]&lt;TCP port#&gt;] | telnet://&lt;host&gt;[:&lt;TCP p
         <li><span class="syntax">/KR=SJIS</span></li>
         <li><span class="syntax">/KR=EUC</span></li>
         <li><span class="syntax">/KR=JIS</span></li>
-        <li><span class="syntax">/KR=UTF8</span> UTF-8(Normalization Form C: Windows, Linux)</li>
-        <li><span class="syntax">/KR=UTF8m</span> UTF-8(Normalization Form D: Mac OS X)</li>
+        <li><span class="syntax">/KR=UTF8</span> UTF-8</li>
         <li><span class="syntax">/KR=KS5601</span> for Korean mode</li>
       </ul></dd>
 

--- a/doc/en/html/macro/command/callmenu.html
+++ b/doc/en/html/macro/command/callmenu.html
@@ -90,7 +90,6 @@ end
 ;callmenu 54112  ; [KanjiCode] Send: JIS
 callmenu 54013  ; [KanjiCode] Recv: UTF-8
 callmenu 54113  ; [KanjiCode] Send: UTF-8
-;callmenu 54014  ; [KanjiCode] Recv: UTF-8m
 </pre>
 
 

--- a/doc/en/html/menu/setup-terminal_ko.html
+++ b/doc/en/html/menu/setup-terminal_ko.html
@@ -111,7 +111,7 @@
 
       <dt id="KanjiReceive">Coding (receive)</dt>
       <dd>
-	Character code that is received from host(KS5601, UTF-8 and UTF-8m).
+	Character code that is received from host(KS5601 and  UTF-8).
       </dd>
 
       <dt id="KanjiSend">Coding (transmit)</dt>

--- a/doc/en/html/menu/setup-terminal_utf8.html
+++ b/doc/en/html/menu/setup-terminal_utf8.html
@@ -111,7 +111,7 @@
 
       <dt id="KanjiReceive">Coding (receive)</dt>
       <dd>
-	Character code that is received from host(UTF-8 and UTF-8m).
+	Character code that is received from host(UTF-8).
       </dd>
 
       <dt id="KanjiSend">Coding (transmit)</dt>

--- a/doc/en/html/reference/menu_id.html
+++ b/doc/en/html/reference/menu_id.html
@@ -361,10 +361,6 @@ Menu ID is used in a <a href="../setup/keyboard.html">keyboard setup file</a>.
     <td>54013</td>
   </tr>
   <tr>
-    <td>[KanjiCode] Recv: UTF-8m</td>
-    <td>54014</td>
-  </tr>
-  <tr>
     <td>[KanjiCode] Send: Shift_JIS</td>
     <td>54110</td>
   </tr>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -43,6 +43,7 @@
         <li>ホストリストを広くした。</li>
       </ul>
       <li>MACRO: <a href="../macro/command/listbox.html">listbox</a> で表示されるダイアログをリサイズできるようにした。</li>
+      <li><a href="../commandline/teraterm.html#kr">/KR</a>, <a href="../commandline/teraterm.html#kt">/KT</a> コマンドラインオプションで、UTF8mを削除した。</li>
     </ul>
   </li>
 

--- a/doc/ja/html/commandline/teraterm.html
+++ b/doc/ja/html/commandline/teraterm.html
@@ -176,8 +176,7 @@ TTERMPRO [ &lt;host&gt;[[:]&lt;TCP port#&gt;] | telnet://&lt;host&gt;[:&lt;TCP p
         <li><span class="syntax">/KR=SJIS</span></li>
         <li><span class="syntax">/KR=EUC</span></li>
         <li><span class="syntax">/KR=JIS</span></li>
-        <li><span class="syntax">/KR=UTF8</span> UTF-8(正規化形式 C: Windows, Linux)</li>
-        <li><span class="syntax">/KR=UTF8m</span> UTF-8(正規化形式 D: Mac OS X)</li>
+        <li><span class="syntax">/KR=UTF8</span> UTF-8</li>
         <li><span class="syntax">/KR=KS5601</span> 韓国語モード用</li>
       </ul></dd>
 

--- a/doc/ja/html/macro/command/callmenu.html
+++ b/doc/ja/html/macro/command/callmenu.html
@@ -90,7 +90,6 @@ end
 ;callmenu 54112  ; [KanjiCode] Send: JIS
 callmenu 54013  ; [KanjiCode] Recv: UTF-8
 callmenu 54113  ; [KanjiCode] Send: UTF-8
-;callmenu 54014  ; [KanjiCode] Recv: UTF-8m
 </pre>
 
 

--- a/doc/ja/html/menu/setup-terminal_ko.html
+++ b/doc/ja/html/menu/setup-terminal_ko.html
@@ -112,7 +112,7 @@
 
       <dt id="KanjiReceive">Coding (receive)</dt>
       <dd>
-	ホストから送られてくる文字コード (KS5601, UTF-8, UTF-8m の3種類)。
+	ホストから送られてくる文字コード (KS5601, UTF-8 の2種類)。
       </dd>
 
       <dt id="KanjiSend">Coding (transmit)</dt>

--- a/doc/ja/html/menu/setup-terminal_utf8.html
+++ b/doc/ja/html/menu/setup-terminal_utf8.html
@@ -112,7 +112,7 @@
 
       <dt id="KanjiReceive">Coding (receive)</dt>
       <dd>
-	ホストから送られてくる文字コード (UTF-8, UTF-8m の2種類)。
+	ホストから送られてくる文字コード (UTF-8 の1種類)。
       </dd>
 
       <dt id="KanjiSend">Coding (transmit)</dt>

--- a/doc/ja/html/reference/menu_id.html
+++ b/doc/ja/html/reference/menu_id.html
@@ -360,10 +360,6 @@
     <td>54013</td>
   </tr>
   <tr>
-    <td>[KanjiCode] Recv: UTF-8m</td>
-    <td>54014</td>
-  </tr>
-  <tr>
     <td>[KanjiCode] Send: Shift_JIS</td>
     <td>54110</td>
   </tr>

--- a/doc/ja/html/usage/kcodechange.html
+++ b/doc/ja/html/usage/kcodechange.html
@@ -29,7 +29,7 @@ TTXKcodeChange ƒvƒ‰ƒOƒCƒ“‚ð“ü‚ê‚é‚ÆAƒŠƒ‚[ƒg‘¤‚©‚ç§ŒäƒV[ƒPƒ“ƒX‚ðŽg—p‚µ‚Ä‘—Žó
 KT  -- ‘—MŠ¿ŽšƒR[ƒh
        Value‚Æ‚µ‚Ä SJIS, EUC, JIS, UTF8 ‚ðŽó‚¯•t‚¯‚Ü‚·B
 KR  -- ŽóMŠ¿ŽšƒR[ƒh
-       Value‚Æ‚µ‚Ä SJIS, EUC, JIS, UTF8, UTF8m ‚ðŽó‚¯•t‚¯‚Ü‚·B
+       Value‚Æ‚µ‚Ä SJIS, EUC, JIS, UTF8 ‚ðŽó‚¯•t‚¯‚Ü‚·B
 </pre>
   </dd>
 </dl>

--- a/installer/release/lang_utf8/Spanish.lng
+++ b/installer/release/lang_utf8/Spanish.lng
@@ -1,4 +1,4 @@
-﻿; Updated by TeraTerm Project (2023-12-02)
+﻿; Updated by TeraTerm Project (2024-01-25)
 ; Traducido por Filiberto Olguin Ascona.
 
 [Tera Term]
@@ -1085,7 +1085,6 @@ MENU_RECV_SJIS=Recv: &Shift_JIS
 MENU_RECV_EUCJP=Recv: &EUC-JP
 MENU_RECV_JIS=Recv: &JIS
 MENU_RECV_UTF8=Recv: &UTF-8
-MENU_RECV_UTF8m=Recv: UTF-8&m
 MENU_RECV_KS5601=Recv: &KS5601
 MENU_SEND_SJIS=Send: S&hift_JIS
 MENU_SEND_EUCJP=Send: EU&C-JP
@@ -1097,7 +1096,6 @@ MENU_SJIS=Recv/Send: &Shift_JIS
 MENU_EUCJP=Recv/Send: &EUC-JP
 MENU_JIS=Recv/Send: &JIS
 MENU_UTF8=Recv/Send: &UTF-8
-MENU_UTF8m=Recv: UTF-8&m/Send: UTF-8
 MENU_KS5601=Recv/Send: &KS5601
 
 

--- a/teraterm/ttpset/ttset.c
+++ b/teraterm/ttpset/ttset.c
@@ -3796,12 +3796,6 @@ void PASCAL _ParseParam(wchar_t *Param, PTTSet ts, PCHAR DDETopic)
 		}
 		else if ((_wcsnicmp(Temp, L"/KR=", 4) == 0) ||
 		         (_wcsnicmp(Temp, L"/KT=", 4) == 0)) {	/* kanji code */
-#if 1
-			if (_wcsicmp(&Temp[4], L"UTF8m") == 0 ||
-			    _wcsicmp(&Temp[4], L"UTF-8m") == 0)
-				c = IdUTF8;
-			else
-#endif
 			if (_wcsicmp(&Temp[4], L"UTF8") == 0 ||
 			         _wcsicmp(&Temp[4], L"UTF-8") == 0)
 				c = IdUTF8;


### PR DESCRIPTION
- Tera Term 4 に存在していた文字コード
  - Tera Term 5 では UTF-8 と UTF-8m を分ける必要がなくなった
- 5ed92d3 (r9528) でコマンドラインオプション /KR,/KT に UTF8m が指定されると UTF8 と同等としていた