### PR TITLE
ttermpro.exe の FileDescription が長いので元に戻す #119

### DIFF
--- a/teraterm/teraterm/tt-version.rc
+++ b/teraterm/teraterm/tt-version.rc
@@ -23,7 +23,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "CompanyName", "T. Teranishi, TeraTerm Project"
-            VALUE "FileDescription", "Tera Term is open source free software terminal emulator"
+            VALUE "FileDescription", "Tera Term"
             VALUE "FileVersion", TT_RES_VERSION_STR
             VALUE "InternalName", "TTERMPRO"
             VALUE "LegalCopyright", "Copyright (C) 1994-1998 T. Teranishi, (C) 2004-2023 TeraTerm Project"


### PR DESCRIPTION
- a069aba で長くした
- タスクマネージャーのプロセス名に使用される
- 見にくくなるので元に戻す