### PR TITLE
ttpmacro の TTLファイル指定の扱いを変更した #127

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -34,10 +34,11 @@
 
 <h3 id="teraterm_5.3">YYYY.MM.DD (Ver 5.3 not released yet)</h3>
 <ul class="history">
-  <!--li>Changes
+  <li>Changes
     <ul>
-      <li></li>
-  </li-->
+      <li>MACRO: When TTL file is relative path, it is relative from current directory of ttpmacro.</li>
+    </ul>
+  </li>
 
   <!--li>Bug fixes
     <ul>

--- a/doc/en/html/macro/commandline.html
+++ b/doc/en/html/macro/commandline.html
@@ -28,7 +28,7 @@
 
   <dt>&lt;macro file&gt;</dt>
   <dd>Macro filename.<br>
-      If this value is not a full path, it is understood as a relative path from <a href="../setup/folder.html">folder with TERATERM.INI</a><br>
+      If this value is not a full path, it is understood as a relative path from current folder.<br>
       The filename(path excluded) is stored in the system variable "param1" and "params[1]".<br>
       When macro file is not specified or is "*", ttpmacro open dialog to select ttl file.
   </dd>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -34,10 +34,11 @@
 
 <h3 id="teraterm_5.3">YYYY.MM.DD (Ver 5.3 not released yet)</h3>
 <ul class="history">
-  <!--li>変更
+  <li>変更
     <ul>
-      <li></li>
-  </li-->
+      <li>MACRO: TTLファイルを相対パスで指定したとき、ttpmacroのカレントディレクトリ相対で扱うようにした。</li>
+    </ul>
+  </li>
 
   <!--li>バグ修正
     <ul>

--- a/doc/ja/html/macro/commandline.html
+++ b/doc/ja/html/macro/commandline.html
@@ -28,9 +28,9 @@
 
   <dt>&lt;macro file&gt;</dt>
   <dd>マクロファイル名<br>
-      ファイル名が絶対パスでないときは、<a href="../setup/folder.html">TERATERM.INI のあるフォルダ</a>からの相対パスと見なされる。<br>
+      ファイル名が絶対パスでないときは、カレントフォルダからの相対パスと見なされる。<br>
       ファイル名（パスを除く）はシステム変数 param1 および params[1] に格納される。<br>
-      macro file を指定しない、又は "*" を指定した場合、TTLファイルを選択するダイアログが表示される
+      macro file を指定しない、又は "*" を指定した場合、TTLファイルを選択するダイアログが表示される。
   </dd>
 
   <dt>&lt;parameters&gt;</dt>

--- a/teraterm/ttpmacro/ttmdlg.h
+++ b/teraterm/ttpmacro/ttmdlg.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 void ParseParam(PBOOL IOption, PBOOL VOption);
-BOOL GetFileName(HWND HWin);
+BOOL GetFileName(HWND HWin, wchar_t **fname);
 void SetDlgPos(int x, int y);
 void OpenInpDlg(wchar_t *Input, const wchar_t *Text, const wchar_t *Caption,
                 const wchar_t *Default, BOOL Paswd);


### PR DESCRIPTION
- ttpmacroにTTLファイルを相対パスで指定したとき、ttpmacroのカレントディレクトリ相対で扱うようにした
  - コマンドライン(シェル)から起動したときの動作が自然になった
  - 変更前は、読み込む TERATERM.INI のあるフォルダ相対で扱っていた
- マニュアルを修正