### PR TITLE
ttxsshの鍵ファイル名にUnicodeを使用できるようにする

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -3485,6 +3485,7 @@ SYNOPSIS:
   <li>Misc
     <ul>
       <li>If option(<a href="../commandline/ttssh.html#f">/f</a>, <a href="../commandline/ttssh.html#ssh-f">/ssh-f</a>, <a href="../commandline/ttssh.html#ssh-consume">/ssh-consume</a>, <a href="../commandline/ttssh.html#keyfile">/keyfile</a>) argument file name is not absolute path, modify it to be treated as a relative path from %APPDATA%\teraterm5\.</li>
+      <li>Modified private key file name can use Unicode</li>
     </ul>
   </li>
 </ul>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -3481,6 +3481,7 @@
   <li>変更
     <ul>
       <li>オプション(<a href="../commandline/ttssh.html#f">/f</a>, <a href="../commandline/ttssh.html#ssh-f">/ssh-f</a>, <a href="../commandline/ttssh.html#ssh-consume">/ssh-consume</a>, <a href="../commandline/ttssh.html#keyfile">/keyfile</a>)のファイル名が絶対パスでないときは、%APPDATA%\teraterm5\ からの相対パスとして扱うように変更した。</li>
+      <li>秘密鍵ファイル名にUnicodeを使用できるよう修正した</li>
     </ul>
   </li>
 

--- a/ttssh2/ttxssh/auth.c
+++ b/ttssh2/ttxssh/auth.c
@@ -380,9 +380,9 @@ static void init_auth_dlg(PTInstVar pvar, HWND dlg, BOOL *UseControlChar)
 		}
 	}
 
-	SetDlgItemText(dlg, IDC_RSAFILENAME,
-	               pvar->session_settings.DefaultRSAPrivateKeyFile);
-	SetDlgItemText(dlg, IDC_HOSTRSAFILENAME,
+	SetDlgItemTextW(dlg, IDC_RSAFILENAME,
+	                pvar->session_settings.DefaultRSAPrivateKeyFile);
+	SetDlgItemTextW(dlg, IDC_HOSTRSAFILENAME,
 	               pvar->session_settings.DefaultRhostsHostPrivateKeyFile);
 	SetDlgItemText(dlg, IDC_LOCALUSERNAME,
 	               pvar->session_settings.DefaultRhostsLocalUserName);
@@ -393,7 +393,7 @@ static void init_auth_dlg(PTInstVar pvar, HWND dlg, BOOL *UseControlChar)
 	} else if (pvar->ssh2_authmethod == SSH_AUTH_RSA) {
 		CheckRadioButton(dlg, IDC_SSHUSEPASSWORD, MAX_AUTH_CONTROL, IDC_SSHUSERSA);
 
-		SetDlgItemText(dlg, IDC_RSAFILENAME, pvar->ssh2_keyfile);
+		SetDlgItemTextW(dlg, IDC_RSAFILENAME, pvar->ssh2_keyfile);
 		if (pvar->ssh2_autologin == 1) {
 			EnableWindow(GetDlgItem(dlg, IDC_CHOOSERSAFILE), FALSE);
 			EnableWindow(GetDlgItem(dlg, IDC_RSAFILENAME), FALSE);
@@ -457,7 +457,12 @@ static char *alloc_control_text(HWND ctl)
 	return textA;
 }
 
-static int get_key_file_name(HWND parent, char *buf, int bufsize, PTInstVar pvar)
+/**
+ *	ファイル名を返す
+ *	@retval		ファイル名(不要になったらfree()すること)
+ *	@retval		NULL キャンセルが押された
+ */
+static wchar_t *get_key_file_name(HWND parent, const wchar_t *UILanguageFileW)
 {
 	static const wchar_t *fullname_def = L"identity";
 	static const wchar_t *filter_def =
@@ -471,7 +476,6 @@ static int get_key_file_name(HWND parent, char *buf, int bufsize, PTInstVar pvar
 		L"PEM files(*.pem)\\0*.pem\\0"
 		L"all(*.*)\\0*.*\\0"
 		L"\\0";
-	const wchar_t *UILanguageFileW = pvar->ts->UILanguageFileW;
 	TTOPENFILENAMEW params;
 	wchar_t *filter;
 	wchar_t *title;
@@ -497,33 +501,32 @@ static int get_key_file_name(HWND parent, char *buf, int bufsize, PTInstVar pvar
 	free(filter);
 	free(title);
 	if (r == FALSE) {
-		buf[0] = 0;
-		return 0;
+		return NULL;
 	}
 	else {
-		char *fullnameA = ToCharW(fullnameW);
-		copy_teraterm_dir_relative_path(buf, bufsize, fullnameA);
-		free(fullnameA);
-		free(fullnameW);
-		return 1;
+		return fullnameW;
 	}
 }
 
 static void choose_RSA_key_file(HWND dlg, PTInstVar pvar)
 {
-	char buf[1024];
+	wchar_t *filename;
 
-	if (get_key_file_name(dlg, buf, sizeof(buf), pvar)) {
-		SetDlgItemText(dlg, IDC_RSAFILENAME, buf);
+	filename = get_key_file_name(dlg, pvar->ts->UILanguageFileW);
+	if (filename != NULL) {
+		SetDlgItemTextW(dlg, IDC_RSAFILENAME, filename);
+		free(filename);
 	}
 }
 
 static void choose_host_RSA_key_file(HWND dlg, PTInstVar pvar)
 {
-	char buf[1024];
+	wchar_t *filename;
 
-	if (get_key_file_name(dlg, buf, sizeof(buf), pvar)) {
-		SetDlgItemText(dlg, IDC_HOSTRSAFILENAME, buf);
+	filename = get_key_file_name(dlg, pvar->ts->UILanguageFileW);
+	if (filename != NULL) {
+		SetDlgItemTextW(dlg, IDC_HOSTRSAFILENAME, filename);
+		free(filename);
 	}
 }
 
@@ -549,12 +552,12 @@ static BOOL end_auth_dlg(PTInstVar pvar, HWND dlg)
 	}
 
 	if (method == SSH_AUTH_RSA || method == SSH_AUTH_RHOSTS_RSA) {
-		char keyfile[2048];
+		wchar_t keyfile[2048];
 		int file_ctl_ID =
 			method == SSH_AUTH_RSA ? IDC_RSAFILENAME : IDC_HOSTRSAFILENAME;
 
 		keyfile[0] = 0;
-		GetDlgItemText(dlg, file_ctl_ID, keyfile, sizeof(keyfile));
+		GetDlgItemTextW(dlg, file_ctl_ID, keyfile, _countof(keyfile));
 		if (keyfile[0] == 0) {
 			UTIL_get_lang_msg("MSG_KEYSPECIFY_ERROR", pvar,
 			                  "You must specify a file containing the RSA/DSA/ECDSA/ED25519 private key.");
@@ -760,14 +763,12 @@ static BOOL end_auth_dlg(PTInstVar pvar, HWND dlg)
 	}
 	pvar->auth_state.auth_dialog = NULL;
 
-	GetDlgItemText(dlg, IDC_RSAFILENAME,
-	               pvar->session_settings.DefaultRSAPrivateKeyFile,
-	               sizeof(pvar->session_settings.
-	                      DefaultRSAPrivateKeyFile));
-	GetDlgItemText(dlg, IDC_HOSTRSAFILENAME,
-	               pvar->session_settings.DefaultRhostsHostPrivateKeyFile,
-	               sizeof(pvar->session_settings.
-	                      DefaultRhostsHostPrivateKeyFile));
+	GetDlgItemTextW(dlg, IDC_RSAFILENAME,
+					pvar->session_settings.DefaultRSAPrivateKeyFile,
+					_countof(pvar->session_settings.DefaultRSAPrivateKeyFile));
+	GetDlgItemTextW(dlg, IDC_HOSTRSAFILENAME,
+	                pvar->session_settings.DefaultRhostsHostPrivateKeyFile,
+					_countof(pvar->session_settings.DefaultRhostsHostPrivateKeyFile));
 	GetDlgItemText(dlg, IDC_LOCALUSERNAME,
 	               pvar->session_settings.DefaultRhostsLocalUserName,
 	               sizeof(pvar->session_settings.
@@ -1528,10 +1529,8 @@ static void init_default_auth_dlg(PTInstVar pvar, HWND dlg)
 	}
 
 	SetDlgItemText(dlg, IDC_SSHUSERNAME, pvar->settings.DefaultUserName);
-	SetDlgItemText(dlg, IDC_RSAFILENAME,
-	               pvar->settings.DefaultRSAPrivateKeyFile);
-	SetDlgItemText(dlg, IDC_HOSTRSAFILENAME,
-	               pvar->settings.DefaultRhostsHostPrivateKeyFile);
+	SetDlgItemTextW(dlg, IDC_RSAFILENAME, pvar->settings.DefaultRSAPrivateKeyFile);
+	SetDlgItemTextW(dlg, IDC_HOSTRSAFILENAME, pvar->settings.DefaultRhostsHostPrivateKeyFile);
 	SetDlgItemText(dlg, IDC_LOCALUSERNAME,
 	               pvar->settings.DefaultRhostsLocalUserName);
 
@@ -1577,12 +1576,12 @@ static BOOL end_default_auth_dlg(PTInstVar pvar, HWND dlg)
 
 	GetDlgItemText(dlg, IDC_SSHUSERNAME, pvar->settings.DefaultUserName,
 	               sizeof(pvar->settings.DefaultUserName));
-	GetDlgItemText(dlg, IDC_RSAFILENAME,
-	               pvar->settings.DefaultRSAPrivateKeyFile,
-	               sizeof(pvar->settings.DefaultRSAPrivateKeyFile));
-	GetDlgItemText(dlg, IDC_HOSTRSAFILENAME,
-	               pvar->settings.DefaultRhostsHostPrivateKeyFile,
-	               sizeof(pvar->settings.DefaultRhostsHostPrivateKeyFile));
+	GetDlgItemTextW(dlg, IDC_RSAFILENAME,
+	                pvar->settings.DefaultRSAPrivateKeyFile,
+	                _countof(pvar->settings.DefaultRSAPrivateKeyFile));
+	GetDlgItemTextW(dlg, IDC_HOSTRSAFILENAME,
+	                pvar->settings.DefaultRhostsHostPrivateKeyFile,
+				    _countof(pvar->settings.DefaultRhostsHostPrivateKeyFile));
 	GetDlgItemText(dlg, IDC_LOCALUSERNAME,
 	               pvar->settings.DefaultRhostsLocalUserName,
 	               sizeof(pvar->settings.DefaultRhostsLocalUserName));

--- a/ttssh2/ttxssh/keyfiles.c
+++ b/ttssh2/ttxssh/keyfiles.c
@@ -123,12 +123,12 @@ static BOOL normalize_key(RSA *key)
 }
 
 static RSA *read_RSA_private_key(PTInstVar pvar,
-                                 char * relative_name,
+                                 const wchar_t * relative_name,
                                  char * passphrase,
                                  BOOL * invalid_passphrase,
                                  BOOL is_auto_login)
 {
-	char filename[2048];
+	wchar_t *filename;
 	int fd;
 	unsigned int length, amount_read;
 	unsigned char *keyfile_data;
@@ -140,10 +140,10 @@ static RSA *read_RSA_private_key(PTInstVar pvar,
 
 	*invalid_passphrase = FALSE;
 
-	get_teraterm_dir_relative_name(filename, sizeof(filename),
-	                               relative_name);
+	filename = get_teraterm_dir_relative_nameW(relative_name);
 
-	fd = _open(filename, _O_RDONLY | _O_SEQUENTIAL | _O_BINARY);
+	fd = _wopen(filename, _O_RDONLY | _O_SEQUENTIAL | _O_BINARY);
+	free(filename);
 	if (fd == -1) {
 		if (errno == ENOENT) {
 			UTIL_get_lang_msg("MSG_KEYFILES_READ_ENOENT_ERROR", pvar,
@@ -345,7 +345,7 @@ static RSA *read_RSA_private_key(PTInstVar pvar,
 }
 
 Key *KEYFILES_read_private_key(PTInstVar pvar,
-                               char * relative_name,
+                               const wchar_t * relative_name,
                                char * passphrase,
                                BOOL * invalid_passphrase,
                                BOOL is_auto_login)
@@ -1802,21 +1802,19 @@ error:
 	return (NULL);
 }
 
-ssh2_keyfile_type get_ssh2_keytype(char *relative_name,
+ssh2_keyfile_type get_ssh2_keytype(const wchar_t *relative_name,
                                    FILE **fp,
                                    char *errmsg,
                                    int errmsg_len) {
 	ssh2_keyfile_type ret = SSH2_KEYFILE_TYPE_NONE;
-	char filename[2048];
+	wchar_t *filename;
 	char line[200];
 	int i;
 
-	// 相対パスを絶対パスへ変換する。こうすることにより、「ドットで始まる」ディレクトリに
-	// あるファイルを読み込むことができる。(2005.2.7 yutaka)
-	get_teraterm_dir_relative_name(filename, sizeof(filename),
-	                               relative_name);
+	filename = get_teraterm_dir_relative_nameW(relative_name);
 
-	*fp = fopen(filename, "r");
+	*fp = _wfopen(filename, L"r");
+	free(filename);
 	if (*fp == NULL) {
 		strncpy_s(errmsg, errmsg_len, strerror(errno), _TRUNCATE);
 		return ret;

--- a/ttssh2/ttxssh/keyfiles.h
+++ b/ttssh2/ttxssh/keyfiles.h
@@ -43,7 +43,7 @@ typedef enum {
 } ssh2_keyfile_type;
 
 Key * KEYFILES_read_private_key(PTInstVar pvar,
-                                char * relative_name,
+                                const wchar_t * relative_name,
                                 char * passphrase,
                                 BOOL * invalid_passphrase,
                                 BOOL is_auto_login);
@@ -72,7 +72,7 @@ Key *read_SSH2_SECSH_private_key(PTInstVar pvar,
                                  char *errmsg,
                                  int errmsg_len);
 
-ssh2_keyfile_type get_ssh2_keytype(char *relative_name,
+ssh2_keyfile_type get_ssh2_keytype(const wchar_t *relative_name,
                                    FILE **fp,
                                    char *errmsg,
                                    int errmsg_len);

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -4995,10 +4995,16 @@ BOOL WINAPI DllMain(HANDLE hInstance,
 			pvar->ts_SSH =
 				(TS_SSH *) MapViewOfFile(__mem_mapping, FILE_MAP_WRITE, 0,
 				                         0, 0);
+			if (pvar->ts_SSH->struct_size != sizeof(TS_SSH)) {
+				// 構造体サイズが異なっていたら共有メモリは使用しない
+				// バージョンが異なるときや開発時に発生する
+				pvar->ts_SSH = NULL;
+			}
 		}
 		if (pvar->ts_SSH == NULL) {
 			/* fake it. The settings won't be shared, but what the heck. */
 			pvar->ts_SSH = (TS_SSH *) malloc(sizeof(TS_SSH));
+			pvar->ts_SSH->struct_size = sizeof(TS_SSH);
 			if (__mem_mapping != NULL) {
 				CloseHandle(__mem_mapping);
 			}

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -268,9 +268,19 @@ static BOOL read_BOOL_option(const wchar_t *fileName, char *keyName, BOOL def)
 static void read_string_option(const wchar_t *fileName, char *keyName,
                                char *def, char *buf, int bufSize)
 {
-
 	buf[0] = 0;
-	GetPrivateProfileString("TTSSH", keyName, def, buf, bufSize, fileName);
+	GetPrivateProfileStringAFileW("TTSSH", keyName, def, buf, bufSize, fileName);
+}
+
+static void read_string_optionW(const wchar_t *fileName, const char *keyName,
+                                char *def, wchar_t *bufW, size_t bufSize)
+{
+	wchar_t *keyW = ToWcharA(keyName);
+	wchar_t *defW = ToWcharA(def);
+	bufW[0] = 0;
+	GetPrivateProfileStringW(L"TTSSH", keyW, defW, bufW, (DWORD)bufSize, fileName);
+	free(keyW);
+	free(defW);
 }
 
 static void read_ssh_options(PTInstVar pvar, const wchar_t *fileName)
@@ -280,6 +290,8 @@ static void read_ssh_options(PTInstVar pvar, const wchar_t *fileName)
 
 #define READ_STD_STRING_OPTION(name) \
 	read_string_option(fileName, #name, "", settings->name, sizeof(settings->name))
+#define READ_STD_STRING_OPTIONW(name) \
+	read_string_optionW(fileName, #name, "", settings->name, sizeof(settings->name))
 
 	settings->Enabled = read_BOOL_option(fileName, "Enabled", FALSE);
 
@@ -296,8 +308,8 @@ static void read_ssh_options(PTInstVar pvar, const wchar_t *fileName)
 
 	READ_STD_STRING_OPTION(DefaultForwarding);
 	READ_STD_STRING_OPTION(DefaultRhostsLocalUserName);
-	READ_STD_STRING_OPTION(DefaultRhostsHostPrivateKeyFile);
-	READ_STD_STRING_OPTION(DefaultRSAPrivateKeyFile);
+	READ_STD_STRING_OPTIONW(DefaultRhostsHostPrivateKeyFile);
+	READ_STD_STRING_OPTIONW(DefaultRSAPrivateKeyFile);
 
 	READ_STD_STRING_OPTION(CipherOrder);
 	normalize_cipher_order(settings->CipherOrder);
@@ -473,13 +485,13 @@ static void write_ssh_options(PTInstVar pvar, const wchar_t *fileName,
 	                          settings->DefaultRhostsLocalUserName,
 	                          fileName);
 
-	WritePrivateProfileString("TTSSH", "DefaultRhostsHostPrivateKeyFile",
-	                          settings->DefaultRhostsHostPrivateKeyFile,
-	                          fileName);
+	WritePrivateProfileStringW(L"TTSSH", L"DefaultRhostsHostPrivateKeyFile",
+	                           settings->DefaultRhostsHostPrivateKeyFile,
+	                           fileName);
 
-	WritePrivateProfileString("TTSSH", "DefaultRSAPrivateKeyFile",
-	                          settings->DefaultRSAPrivateKeyFile,
-	                          fileName);
+	WritePrivateProfileStringW(L"TTSSH", L"DefaultRSAPrivateKeyFile",
+	                           settings->DefaultRSAPrivateKeyFile,
+	                           fileName);
 
 	_itoa(settings->DefaultAuthMethod, buf, 10);
 	WritePrivateProfileString("TTSSH", "DefaultAuthMethod", buf, fileName);
@@ -1660,10 +1672,8 @@ static void PASCAL TTXParseParam(wchar_t *param, PTTSet ts, PCHAR DDETopic)
 				WideCharToACP_t(option + 8, pvar->ssh2_password, sizeof(pvar->ssh2_password));
 
 			} else if (wcsncmp(option + 1, L"keyfile=", 8) == 0) {
-				wchar_t *keyfileW = option + 9;
-				keyfileW = get_home_dir_relative_nameW(keyfileW);
-				WideCharToACP_t(keyfileW, pvar->ssh2_keyfile, sizeof(pvar->ssh2_keyfile));
-				free(keyfileW);
+				const wchar_t *keyfileW = option + 9;
+				wcsncpy(pvar->ssh2_keyfile, keyfileW, _countof(pvar->ssh2_keyfile));
 
 			} else if (wcscmp(option + 1, L"ask4passwd") == 0) {
 				// パスワードを聞く (2006.9.18 maya)
@@ -4691,11 +4701,11 @@ static int PASCAL TTXProcessCommand(HWND hWin, WORD cmd)
 }
 
 
-static void _dquote_string(char *str, char *dst, int dst_len)
+static void _dquote_string(const wchar_t *str, wchar_t *dst, size_t dst_len)
 {
-	int i, len, n;
+	size_t i, len, n;
 
-	len = strlen(str);
+	len = wcslen(str);
 	n = 0;
 	for (i = 0 ; i < len ; i++) {
 		if (str[i] == '"')
@@ -4719,48 +4729,58 @@ static void _dquote_string(char *str, char *dst, int dst_len)
 	*dst = '\0';
 }
 
-static void dquote_string(char *str, char *dst, int dst_len)
+static void dquote_stringW(const wchar_t *str, wchar_t *dst, size_t dst_len)
 {
 	// ",スペース,;,^A-^_ が含まれる場合にはクオートする
-	if (strchr(str, '"') != NULL ||
-	    strchr(str, ' ') != NULL ||
-	    strchr(str, ';') != NULL ||
-	    strchr(str, 0x01) != NULL ||
-	    strchr(str, 0x02) != NULL ||
-	    strchr(str, 0x03) != NULL ||
-	    strchr(str, 0x04) != NULL ||
-	    strchr(str, 0x05) != NULL ||
-	    strchr(str, 0x06) != NULL ||
-	    strchr(str, 0x07) != NULL ||
-	    strchr(str, 0x08) != NULL ||
-	    strchr(str, 0x09) != NULL ||
-	    strchr(str, 0x0a) != NULL ||
-	    strchr(str, 0x0b) != NULL ||
-	    strchr(str, 0x0c) != NULL ||
-	    strchr(str, 0x0d) != NULL ||
-	    strchr(str, 0x0e) != NULL ||
-	    strchr(str, 0x0f) != NULL ||
-	    strchr(str, 0x10) != NULL ||
-	    strchr(str, 0x11) != NULL ||
-	    strchr(str, 0x12) != NULL ||
-	    strchr(str, 0x13) != NULL ||
-	    strchr(str, 0x14) != NULL ||
-	    strchr(str, 0x15) != NULL ||
-	    strchr(str, 0x16) != NULL ||
-	    strchr(str, 0x17) != NULL ||
-	    strchr(str, 0x18) != NULL ||
-	    strchr(str, 0x19) != NULL ||
-	    strchr(str, 0x1a) != NULL ||
-	    strchr(str, 0x1b) != NULL ||
-	    strchr(str, 0x1c) != NULL ||
-	    strchr(str, 0x1d) != NULL ||
-	    strchr(str, 0x1e) != NULL ||
-	    strchr(str, 0x1f) != NULL) {
+	if (wcschr(str, '"') != NULL ||
+	    wcschr(str, ' ') != NULL ||
+	    wcschr(str, ';') != NULL ||
+	    wcschr(str, 0x01) != NULL ||
+	    wcschr(str, 0x02) != NULL ||
+	    wcschr(str, 0x03) != NULL ||
+	    wcschr(str, 0x04) != NULL ||
+	    wcschr(str, 0x05) != NULL ||
+	    wcschr(str, 0x06) != NULL ||
+	    wcschr(str, 0x07) != NULL ||
+	    wcschr(str, 0x08) != NULL ||
+	    wcschr(str, 0x09) != NULL ||
+	    wcschr(str, 0x0a) != NULL ||
+	    wcschr(str, 0x0b) != NULL ||
+	    wcschr(str, 0x0c) != NULL ||
+	    wcschr(str, 0x0d) != NULL ||
+	    wcschr(str, 0x0e) != NULL ||
+	    wcschr(str, 0x0f) != NULL ||
+	    wcschr(str, 0x10) != NULL ||
+	    wcschr(str, 0x11) != NULL ||
+	    wcschr(str, 0x12) != NULL ||
+	    wcschr(str, 0x13) != NULL ||
+	    wcschr(str, 0x14) != NULL ||
+	    wcschr(str, 0x15) != NULL ||
+	    wcschr(str, 0x16) != NULL ||
+	    wcschr(str, 0x17) != NULL ||
+	    wcschr(str, 0x18) != NULL ||
+	    wcschr(str, 0x19) != NULL ||
+	    wcschr(str, 0x1a) != NULL ||
+	    wcschr(str, 0x1b) != NULL ||
+	    wcschr(str, 0x1c) != NULL ||
+	    wcschr(str, 0x1d) != NULL ||
+	    wcschr(str, 0x1e) != NULL ||
+	    wcschr(str, 0x1f) != NULL) {
 		_dquote_string(str, dst, dst_len);
 		return;
 	}
 	// そのままコピーして戻る
-	strncpy_s(dst, dst_len, str, _TRUNCATE);
+	wcsncpy_s(dst, dst_len, str, _TRUNCATE);
+}
+
+static void dquote_string(const char *str, char *dst, size_t dst_len)
+{
+	wchar_t *dstW = malloc(sizeof(wchar_t) * dst_len);
+	wchar_t *strW = ToWcharA(str);
+	dquote_stringW(strW, dstW, dst_len);
+	WideCharToACP_t(dstW, dst, dst_len);
+	free(strW);
+	free(dstW);
 }
 
 static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
@@ -4845,13 +4865,14 @@ static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
 
 			} else if (pvar->settings.remember_password &&
 			           pvar->auth_state.cur_cred.method == SSH_AUTH_RSA) {
+				wchar_t markW[MAX_PATH];
 				dquote_string(pvar->auth_state.cur_cred.password, mark, sizeof(mark));
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
 							 L" /auth=publickey /user=%hs /passwd=%hs", pvar->auth_state.user, mark);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
-				dquote_string(pvar->session_settings.DefaultRSAPrivateKeyFile, mark, sizeof(mark));
-				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE, L" /keyfile=%hs", mark);
+				dquote_stringW(pvar->session_settings.DefaultRSAPrivateKeyFile, markW, _countof(markW));
+				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE, L" /keyfile=%s", markW);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
 			} else if (pvar->settings.remember_password &&

--- a/ttssh2/ttxssh/ttxssh.h
+++ b/ttssh2/ttxssh/ttxssh.h
@@ -160,8 +160,8 @@ typedef struct _TS_SSH {
 	char KnownHostsFiles[2048];
 	int DefaultAuthMethod;
 	char DefaultRhostsLocalUserName[256];
-	char DefaultRhostsHostPrivateKeyFile[1024];
-	char DefaultRSAPrivateKeyFile[1024];
+	wchar_t DefaultRhostsHostPrivateKeyFile[1024];
+	wchar_t DefaultRSAPrivateKeyFile[1024];
 
 	char DefaultForwarding[4096];
 	BOOL TryDefaultAuth;
@@ -312,7 +312,7 @@ typedef struct _TInstVar {
 	SSHAuthMethod ssh2_authmethod;
 	char ssh2_username[MAX_PATH];
 	char ssh2_password[MAX_PATH];
-	char ssh2_keyfile[MAX_PATH];
+	wchar_t ssh2_keyfile[MAX_PATH];
 	time_t ssh_heartbeat_tick;
 	HANDLE ssh_heartbeat_thread;
 	int keyboard_interactive_password_input;

--- a/ttssh2/ttxssh/ttxssh.h
+++ b/ttssh2/ttxssh/ttxssh.h
@@ -145,6 +145,7 @@ These are the fields that WOULD go in Tera Term's 'ts' structure, if
 we could put them there.
 */
 typedef struct _TS_SSH {
+	DWORD struct_size;
 	BOOL Enabled;
 	int CompressionLevel; /* 0 = NONE, else 1-9 */
 


### PR DESCRIPTION
- 変更前はACPだった
- `"id_rsa😄"` などもokとなる
