### PR TITLE
絵文字テーブルを変更

### DIFF
--- a/doc/en/html/about/glossary.html
+++ b/doc/en/html/about/glossary.html
@@ -64,23 +64,6 @@ This window is not displayed when Tera Term is started.
 [Control]-[Open TEK] command opens TEK window.
 </dd>
 
-<dt id="UTF-8">UTF-8, UTF-8m</dt>
-<dd>
-  <p>
-    Character code encoded Unicode with MBCS from 1 byte to 4 bytes.
-  </p>
-
-  <p>
-    A single character to be displayed can be created from multiple Unicode characters.
-    ex. U+0061 + U+0302 ( a+ ^ -> &#x00E2; ).
-    Tera Term 4 uses the character code "UTF-8m", which is used in the macOS file system HFS+.
-  </p>
-
-  <p>
-    All UTF-8 can be used with character code "UTF-8" on Tera Term 5
-  </p>
-</dd>
-
 <dt>VT100</dt>
 <dd>Name of DEC(Digital Equipment Corporation)'s terminal.
 The terminal was used widely for Unix, VAX/VMS, and other computers.
@@ -113,6 +96,91 @@ Window for VT terminal emulation.</dd>
 <dd>XMODEM, YMODEM を(それらの原形をとどめないほどに)改良したファイル転送プロトコル。エラー訂正機能が強化され、制御文字の一部を通さない回線にも対応し、転送速度をあげるための工夫がなされています。
 -->
 
+</dl>
+
+<h2>Charactor code</h2>
+
+Glossary related to character codes.
+
+<dl>
+  <dt id="CJK">CJK, CJKV, East Asian characters</dt>
+
+  <dd>
+    <p>
+      Languages with a writing system that includes Kanji characters.
+      CJK(CJKV) = Chinese, Japanese, Korean, (Vietnamese)。
+    </p>
+
+    <p>
+      CJK(CJKV) environment, <a href="#DBCS">Double-byte characters</a> are used
+      to represent a character with two bytes,
+      since not all characters used can be represented with one byte.<br>
+      Before Unicode became popular, character codes were developed for each environment.
+    </p>
+
+    <p>
+      Major DBCS
+<pre>
+| Language                      | Code(CodePage)     |
+|-------------------------------|--------------------|
+| Chinese (Simplified Chinese)  | GB2312(CP936)      |
+| Chinese (Traditional Chinese) | Big5(CP950)        |
+| Japanese                      | `Shift_JIS(CP932)` |
+|                               | EUC(EUC-JP,CP51932)|
+| Korean                        | KS5601(CP949)      |
+</pre>
+
+<!--
+      Tera Termはベトナム語漢字(チュノム)独自の文字コードをサポートしていません。<br>
+      Unicodeを使用した表示には対応してします。
+-->
+
+    </p>
+  </dd>
+
+  <dt id="SBCS">SBCS</dt>
+  <dd>
+    Single-byte character set.<br>
+    Up to 256 types of characters can be represented.
+  </dd>
+
+  <dt id="DBCS">DBCS</dt>
+  <dd>
+    Double-byte character set.<br>
+    DBCS is a character set that extends SBCS and can represent characters including Kanji characters.<br>
+    Mixed 1-byte and 2-byte characters.<br>
+    Shift_jis is one example of DBCS.
+  </dd>
+
+  <dt id="MBCS">MBCS</dt>
+  <dd>
+    Multi-byte Character Set.<br>
+    Characters of 3 bytes or more are used.<br>
+    JIS, UTF-8, etc.
+  </dd>
+
+<dt id="UTF-8">UTF-8, UTF-8m</dt>
+<dd>
+  Character code encoded Unicode with MBCS from 1 byte to 4 bytes.
+
+  <p>
+    A single character to be displayed can be created from multiple Unicode characters.
+    ex. U+0061 + U+0302 ( a+ ^ -> &#x00E2; ).
+    Tera Term 4 uses the character code "UTF-8m", which is used in the macOS file system HFS+.
+  </p>
+
+  <p>
+    "UTF-8m" has been merged into "UTF-8" on Tera Term 5.
+  </p>
+</dd>
+
+  <dt>wide character</dt>
+  <dd>
+    A character representation in which smallest character unit is two or more bytes.<br>
+    In C language, wchar_t type.<br>
+    In C, type wchar_t. In C/C++ language for Windows (Visual Studio), wchar_t type is 2 bytes.<br>
+    The Windows API uses 2-byte wide characters and the character encoding is UTF-16LE.
+  </dd>
 </dl>
 
 </BODY>

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -42,6 +42,7 @@
       <li>Right-click(paste) is not disabled even when <a href="../setup/teraterm-win.html#textselect">SelectOnActivate</a> is off.</li>
       <li>allow users to select creating automatic backup or not by <a href="../setup/teraterm-misc.html#IniAutoBackup">IniAutoBackup</a> when overwriting the ini file.
       <li><a href="../setup/teraterm-win.html#space">VTFontSpace</a> can be used to adjust to narrow the space between characters.
+      <li>Fixed some Emoji which character widths did not change with Override Emoji Characters width option. (Changed referenced Emoji table.)</li>
     </ul>
   </li>
 

--- a/doc/en/html/menu/setup-additional-coding.html
+++ b/doc/en/html/menu/setup-additional-coding.html
@@ -20,7 +20,8 @@
 
     <h2>Override Emoji Characters width</h2>
 
-    When checked, Overrides characters width from East_Asian_Width.
+    When checked, Overrides characters width from East_Asian_Width.<br>
+    Refer to <a href="#emoji">About Emoji width (cells)</a>.
     <ul>
       <li>Emoji with U+1F000 and above are 2Cell (full-width).
       <li>Emoji less than U+1F000:
@@ -62,7 +63,7 @@
 
     <h2>Easy to setup</h2>
     <dl>
-      <dt>Use with Chinese, Japanese, and Korean (CJK)</dt>
+      <dt>Use with Chinese, Japanese, and Korean (<a href="../about/glossary.html#CJK">CJK</a>)</dt>
       <dd>
         Select coding with "Japanese/" etc. such as Japanese/UTF-8<br>
         - Ambiguous Characters Width = 2Cell<br>
@@ -70,12 +71,44 @@
       </dd>
     </dl>
 
+    <h2>Charactor width (cells)</h2>
+
+    <p>
+      Character width for <a href="../about/glossary.html#SBCS">single-byte character code</a> such as Latin-1 is 1 cell.
+    </p>
+
+    <p>
+      Character width for <a href="../about/glossary.html#DBCS">double-byte character code</a> such as Shift_JIS is 1 cell for 1-byte characters and 2 cells for 2-byte characters.
+    </p>
+
+    <p>
+      In Unicode, character width of a single character changes case-by-case.
+    </p>
+
+    Example, "&#x00A7;" (section sign, section mark)
+<pre>
+| code               | charactor code(code point) | cell   |
+|--------------------|----------------------------|--------|
+| ISO8859-1(Latin-1) | 0xA7                       | 1      |
+| Shift_JIS(CP932)   | 0x8198                     | 2      |
+| KS5601(CP949)      | 0xA1D7                     | 2      |
+| Big5(CP950)        | 0xA1B1                     | 2      |
+| BG2312(CP936)      | 0xA1EC                     | 2      |
+| Unicode            | 0xA7 (U+00A7)              | 1 or 2 |
+</pre>
+
+    <p>
+      In a multibyte character code environment (<a href="../about/glossary.html#CJK">CJK</a>), character width should be 2 cell, and in other environments it should be 1 cell for natural use.
+      Type of character whose width changes are called Ambiguous.
+
+      Refer to <a href="#EastAsianWidth">East_Asian_Width and width (cells)</a> for detail.
+
     <h2>About displayed characters</h2>
     test text in Tera Term repository can be displayed and checked.
     <ul>
-      <li>Kanji width<br>
+      <li>Unicode (Kanji) width<br>
         "wget https://github.com/TeraTermProject/teraterm/raw/main/tests/unicodebuf-east_asian_width.txt -O -"
-      <li>Emoji width<br>
+      <li>Unicode Emoji width<br>
         "wget https://raw.githubusercontent.com/TeraTermProject/teraterm/main/tests/unicodebuf-text-emoji.txt -O -"
     </ul>
     Please note the following:
@@ -138,20 +171,8 @@ cells(2=full/1=half)
 </pre>
 
     <p>
-      In a CJK environment, it is more natural to set the Ambiguous character width to 2Cell.<br>
+      In <a href="../about/glossary.html#CJK">CJK</a> environment, it is more natural to set the Ambiguous character width to 2Cell.<br>
       In addition, most Japanese fonts are designed in 2Cell.
-    </p>
-
-    <p>
-      Neutral contains Emoji, that Emoji is unnatural in Japan when rendered in 1cell.
-      Emoji's width can be changed to make them appear more natural.
-
-      <dl>
-        <dt>Example</dt>
-        <dd>U+263A WHITE SMILING FACE</dd>
-        <dd>U+2764 HEAVY BLACK HEART</dd>
-        <dd><a href="https://ja.wikipedia.org/wiki/%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E8%A8%98%E5%8F%B7" target="_blank">Unicode Miscellaneous Symbols (Wikipedia JA)</a></dd>
-      </dl>
     </p>
 
     <p>
@@ -159,7 +180,7 @@ cells(2=full/1=half)
       http://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
     </p>
 
-    <h2>About Emoji</h2>
+    <h2 id="emoji">About Emoji width (cells)</h2>
 
     <p>
       Emoji property is other propery from East Asian Width property.
@@ -167,12 +188,12 @@ cells(2=full/1=half)
 
     <p>
       In the CJK environment, as with the East_Asian_Width property,
-      Characters that are not 1-byte in non-Unicode character codes, 2-cell is more natural.
+      Characters that are 2 byte in DBCS, 2 cell is more natural.
     </p>
 
     <p>
-      In non-CJK environments, many characters handling 1cell is natural, because 2cell characters did not exist in traditional character codes.
-      Emoji with code points U+1F000 or higher that did not exist before Unicode, so they may be handled as 2-cell characters.
+      In non-CJK environments, many characters handling 1 cell is natural, because 2 cell characters did not exist in traditional character codes.
+      Emoji with code points U+1F000 or higher that did not exist before Unicode, so they may be handled as 2 cell characters.
     </p>
 
     <p>
@@ -180,6 +201,19 @@ cells(2=full/1=half)
       https://www.unicode.org/Public/emoji/12.1/emoji-data.txt<br>
       However, code points less than U+0080 are not treated as Emoji
     </p>
+
+    <p>
+      Neutral contains Emoji, that Emoji is unnatural in Japan when rendered in 1cell.
+      Emoji's width can be changed to make them appear more natural.
+    </p>
+
+    <p>Example</p>
+    <dl>
+      <dt>"&#x263a;", U+263A</dt>
+      <dd>WHITE SMILING FACE</dd>
+      <dt>"&#x2764;", U+2764</dt>
+      <dd>HEAVY BLACK HEART</dd>
+    </dl>
 
   </body>
 </html>

--- a/doc/ja/html/about/glossary.html
+++ b/doc/ja/html/about/glossary.html
@@ -53,24 +53,6 @@ Tera Term の Kermit は今のところ基本的機能しか持っていないので、本家の Kermit に
 <dd>TEK 端末のエミュレーションをするウィンドウで、タイトル文字列の一番右に「TEK」と表示されています。Tera Term を起動したときは表示されません。
 [Control] Open TEK コマンドで、TEK window を開くことができます。</dd>
 
-<dt id="UTF-8">UTF-8, UTF-8m</dt>
-<dd>
-  <p>
-    UnicodeをMBCSに符号化した文字コード。1byteから4byteに符号化されます。
-  </p>
-
-  <p>
-    U+307B + U+309A (ほ + (まる)  = ぽ)など、
-    複数のUnicode文字を組み合わせて、表示1文字を表現することができます。
-    Tera Term 4 では macOSのファイルシステムHFS+で使用されていた
-    表現方法を文字コード"UTF-8m"としていました。
-  </p>
-
-  <p>
-    Tera Term 5 では文字コード"UTF-8" で全て使用可能です。
-  </p>
-</dd>
-
 <dt>VT100</dt>
 <dd>DEC 社の端末の名前です。かつて、Unix や VAX/VMS 等のコンピューターの端末として広く用いられていました。現在は、 VT100 そのものはほとんど
 使用されていませんが、その仕様が事実上の標準となっているため、PC や ワークステーションで動く VT100 エミュレーターが多く作られています。<br>
@@ -91,6 +73,92 @@ VT 端末のエミュレーションをします。</dd>
 <dt>ZMODEM</dt>
 <dd>XMODEM, YMODEM を(それらの原形をとどめないほどに)改良したファイル転送プロトコル。エラー訂正機能が強化され、制御文字の一部を通さない回線にも対応し、転送速度をあげるための工夫がなされています。</dd>
 
+</dl>
+
+<h2>文字コード</h2>
+
+文字コードに関連する用語
+
+<dl>
+  <dt id="CJK">CJK, CJKV, 東アジア(East Asian)の文字コード</dt>
+
+  <dd>
+    <p>
+      漢字を含む文字体系を持つ言語。
+      CJK(CJKV) = Chinese(中国語), Japanese(日本語), Korean(韓国語), (Vietnamese(ベトナム語))。
+    </p>
+
+    <p>
+      CJK(CJKV)環境では、使用する全ての文字を1バイトでは表現できないため、
+      1文字を2バイトで表現する<a href="#DBCS">ダブルバイト文字</a>が使用されます。<br>
+      Unicodeが普及する前、各々の環境に合わせた文字コードが策定されました。
+    </p>
+
+    <p>
+      主なDBCS
+<pre>
+| Language                      | Code(CodePage)     |
+|-------------------------------|--------------------|
+| Chinese (Simplified Chinese)  | GB2312(CP936)      |
+| Chinese (Traditional Chinese) | Big5(CP950)        |
+| Japanese                      | `Shift_JIS(CP932)` |
+|                               | EUC(EUC-JP,CP51932)|
+| Korean                        | KS5601(CP949)      |
+</pre>
+
+    <p>
+      Tera Termはベトナム語漢字(チュノム)独自の文字コードをサポートしていません。<br>
+      Unicodeを使用した表示には対応してします。
+    </p>
+<small>TODO ベトナム語漢字はVisual Studioがサポートしていない? CodePageなどを調べても文字コードがわからない</small>
+
+
+    </p>
+  </dd>
+
+  <dt id="SBCS">SBCS</dt>
+  <dd>
+    Single-byte character set, 1バイト文字セット。<br>
+    最大で256種の文字を表現できる。
+  </dd>
+
+  <dt id="DBCS">DBCS</dt>
+  <dd>
+    Double-byte character set, 2 バイト文字セット。<br>
+    SBCSを拡張して漢字なども含めた文字を表現できる。<br>
+    1バイトの文字と2バイトの文字が混在。<br>
+    Shift_jisはDBCSの1例。
+  </dd>
+
+  <dt id="MBCS">MBCS</dt>
+  <dd>
+    Multi-byte Character Set。<br>
+    3バイト以上の文字が使用される。<br>
+    JIS, UTF-8等。
+  </dd>
+
+<dt id="UTF-8">UTF-8, UTF-8m</dt>
+<dd>
+  UnicodeをMBCSに符号化した文字コード。1byteから4byteに符号化されます。
+
+  <p>
+    U+307B + U+309A (ほ + (まる)  = ぽ)など、
+    複数のUnicode文字を組み合わせて、表示1文字を表現することができます。
+    Tera Term 4 では macOSのファイルシステムHFS+で使用されていた
+    表現方法を文字コード"UTF-8m"としていました。
+  </p>
+
+  <p>
+    Tera Term 5 では "UTF-8m" は "UTF-8" に統合されました。
+  </p>
+</dd>
+
+  <dt>wide character, ワイド文字</dt>
+  <dd>
+    最小文字単位を2バイト以上とする文字表現。<br>
+    C言語ではwchar_t型。Windows用C/C++言語(Visual Studio)ではwchar_t型は2byte。<br>
+    WindowsのAPIでは2byteのワイド文字、文字コードはUTF-16LEが使用される。
+  </dd>
 </dl>
 
 </BODY>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -42,6 +42,7 @@
       <li><a href="../setup/teraterm-win.html#textselect">SelectOnActivate</a> が off でも右クリックによる貼り付けは行われるようにした。</li>
       <li>iniファイルを上書きする際に自動バックアップを作成するかどうかを <a href="../setup/teraterm-misc.html#IniAutoBackup">IniAutoBackup</a> で設定できるようにした。</li>
       <li><a href="../setup/teraterm-win.html#space">VTFontSpace</a> で負の値を設定できるようにした。</li>
+      <li>Override Emoji Characters widthで文字幅が変化しない絵文字があったので修正した。(参照する絵文字テーブルを変更した。)</li>
     </ul>
   </li>
 

--- a/doc/ja/html/menu/setup-additional-coding.html
+++ b/doc/ja/html/menu/setup-additional-coding.html
@@ -20,7 +20,8 @@
 
     <h2>Override Emoji Characters width</h2>
 
-    チェックすると、絵文字属性のある文字は East_Asian_Width特性を置き換えて文字幅を設定します。
+    チェックすると、絵文字属性のある文字は East_Asian_Width特性を置き換えて文字幅を設定します。<br>
+    <a href="#emoji">絵文字のセル数について</a>を参照ください。
     <ul>
       <li>コードポイント U+1F000 以上の絵文字は常に2Cell(全角)として扱います。
       <li>コードポイント U+1F000 未満の絵文字は
@@ -63,7 +64,7 @@
 
     <h2>簡単な設定の方法</h2>
     <dl>
-      <dt>中国語,日本語,韓国語(CJK)で使用する場合</dt>
+      <dt>中国語,日本語,韓国語(<a href="../about/glossary.html#CJK">CJK</a>)で使用する場合</dt>
       <dd>
         Japanese/UTF-8 など、"Japanese/" などがついたコーディングを選ぶ<br>
         →Ambiguous Characters Width が 2Cell となる<br>
@@ -71,12 +72,46 @@
       </dd>
     </dl>
 
+    <h2>文字幅(セル数)について</h2>
+
+    <p>
+      Latin-1 など<a href="../about/glossary.html#SBCS">シングルバイト文字コード</a>の文字幅は1cellです。
+    </p>
+
+    <p>
+      Shift_JIS などの<a href="../about/glossary.html#DBCS">ダブルバイト文字コード</a>の文字幅は、1バイト文字は1cell, 2バイト文字は2cellです。
+    </p>
+
+    <p>
+      Unicode では1つの文字の文字幅が場合によって変化します。
+    </p>
+
+    <p>
+    例えば、"§"(section sign,節記号,セクションマーク) の文字コードは次のようになります
+<pre>
+| code               | charactor code(code point) | cell   |
+|--------------------|----------------------------|--------|
+| ISO8859-1(Latin-1) | 0xA7                       | 1      |
+| Shift_JIS(CP932)   | 0x8198                     | 2      |
+| KS5601(CP949)      | 0xA1D7                     | 2      |
+| Big5(CP950)        | 0xA1B1                     | 2      |
+| BG2312(CP936)      | 0xA1EC                     | 2      |
+| Unicode            | 0xA7 (U+00A7)              | 1 or 2 |
+</pre>
+
+    <p>
+      マルチバイト文字コードを使用していた環境(<a href="../about/glossary.html#CJK">CJK</a>)では 2cell で、
+      その他の環境では 1cell で表示すると自然に使用できます。
+      文字幅が変化する文字種をAmbiguous(曖昧)といいます。
+      詳しくは<a href="#EastAsianWidth">East_Asian_Width特性とセル数について</a>を参照ください。
+    </p>
+
     <h2>表示される文字について</h2>
     Tera Term のリポジトリにテスト用テキストがあるので表示してチェックできます。
     <ul>
-      <li>漢字の文字幅<br>
+      <li>Unicode(漢字)の文字幅<br>
         "wget https://github.com/TeraTermProject/teraterm/raw/main/tests/unicodebuf-east_asian_width.txt -O -"
-      <li>絵文字の文字幅<br>
+      <li>Unicode絵文字の文字幅<br>
         "wget https://raw.githubusercontent.com/TeraTermProject/teraterm/main/tests/unicodebuf-text-emoji.txt -O -"
     </ul>
     次のことに注意してください
@@ -103,19 +138,15 @@
       </li>
     </ul>
 
-    <h2 id="EastAsianWidth">East_Asian_Width特性とセル数について</h2>
+    <h2 id="EastAsianWidth">East_Asian_Width特性と文字幅(セル数)について</h2>
 
     <p>
-      East_Asian_Width特性(東アジアの文字幅)として、
-      各文字には特性が割り当てられています。
+      Unicodeでは文字幅を5種類の特性に分類して、
+      East_Asian_Width特性(東アジアの文字幅)として定義しています。
     </p>
 
     <p>
-      この特性は5種類存在し、各々の文字幅が決められています。
-    </p>
-
-    <p>
-      また、文字幅の解釈には次の2種類があります。
+      文字幅の解釈には次の2種類があります。
       <ol>
         <li>東アジアの従来文字コードの文脈の場合</li>
         <li>東アジア以外の従来文字コードの文脈の場合</li>
@@ -139,20 +170,9 @@ cells数(2=全角/1=半角)
 </pre>
 
     <p>
-      CJK環境では、Ambiguousの文字幅を 2Cell にしたほうが自然です。<br>
+      <a href="../about/glossary.html#CJK">CJK</a>環境では、
+      Ambiguousの文字幅を 2Cell にしたほうが自然です。<br>
       また、日本語フォントでは 2Cell でデザインされていることがほとんどだと思われます。
-    </p>
-
-    <p>
-      Neutralには絵文字が入っていて、1cellで描画すると日本では不自然な表示となります。
-      絵文字の時の文字幅を変更することで自然な表示とすることができます。
-
-      <dl>
-        <dt>例</dt>
-        <dd>U+263A WHITE SMILING FACE</dd>
-        <dd>U+2764 HEAVY BLACK HEART</dd>
-        <dd><a href="https://ja.wikipedia.org/wiki/%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E8%A8%98%E5%8F%B7" target="_blank">Unicode その他の記号 (Miscellaneous Symbols) について(Wikipedia)</a></dd>
-      </dl>
     </p>
 
     <p>
@@ -160,7 +180,7 @@ cells数(2=全角/1=半角)
       http://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt
     </p>
 
-    <h2>絵文字について</h2>
+    <h2 id="emoji">絵文字の文字幅(セル数)について</h2>
 
     <p>
       絵文字属性は East Asian Width の特性とは別の文字特性です。
@@ -168,8 +188,7 @@ cells数(2=全角/1=半角)
 
     <p>
       CJK環境では、East_Asian_Width特性と同様、
-      従来の文字コードで1byteで表現できない文字は
-      2Cell で扱うほうが自然です。
+      DBCS で 2byte の文字は 2Cell で扱うほうが自然です。
     </p>
 
     <p>
@@ -183,6 +202,19 @@ cells数(2=全角/1=半角)
       https://www.unicode.org/Public/emoji/12.1/emoji-data.txt<br>
       ただし、コードポイントU+0080未満は絵文字として扱いません。
     </p>
+
+    <p>
+      Neutralには絵文字が入っていて、1cellで描画すると日本では不自然な表示となります。
+      絵文字の時の文字幅を変更することで自然な表示とすることができます。
+    </p>
+
+    <p>例</p>
+    <dl>
+      <dt>"&#x263a;", U+263A</dt>
+      <dd>WHITE SMILING FACE</dd>
+      <dt>"&#x2764;", U+2764</dt>
+      <dd>HEAVY BLACK HEART</dd>
+    </dl>
 
   </body>
 </html>

--- a/teraterm/teraterm/unicode/get_emoji_table.pl
+++ b/teraterm/teraterm/unicode/get_emoji_table.pl
@@ -31,6 +31,8 @@ $v = <$fh>;
 chop($v);
 print $fh_out "// $v\n";
 
+my $block_start = 6;
+my $block_count = 0;
 my $block = 0;
 my $start;
 my $end;
@@ -40,10 +42,16 @@ my $ocomment;
 my $oend = 0;
 while(my $a = <$fh>) {
 	if ($a =~ /^# ======/) {
-		$block = $block + 1;
-		if ($block == 2) {
+		if ($block == 0) {
+			$block_count = $block_count + 1;
+			if ($block_count == $block_start) {
+				$block = 1;
+			}
+		} else {
 			last;
 		}
+	} elsif ($block == 0) {
+		next;
 	}
 
 	if ($a =~ /^([0-9A-F]+)\.\.([0-9A-F]+).+\)\s+(.+)$/) {

--- a/teraterm/teraterm/unicode_emoji.tbl
+++ b/teraterm/teraterm/unicode_emoji.tbl
@@ -11,6 +11,7 @@
 { 0x0021a9, 0x0021aa }, // right arrow curving left..left arrow curving right
 { 0x00231a, 0x00231b }, // watch..hourglass done
 { 0x002328, 0x002328 }, // keyboard
+{ 0x002388, 0x002388 }, // HELM SYMBOL
 { 0x0023cf, 0x0023cf }, // eject button
 { 0x0023e9, 0x0023f3 }, // fast-forward button..fast down button
 { 0x0023f8, 0x0023fa }, // pause button..record button
@@ -19,49 +20,11 @@
 { 0x0025b6, 0x0025b6 }, // play button
 { 0x0025c0, 0x0025c0 }, // reverse button
 { 0x0025fb, 0x0025fe }, // white medium square..black medium-small square
-{ 0x002600, 0x002604 }, // sun..cloud
-{ 0x00260e, 0x00260e }, // telephone
-{ 0x002611, 0x002611 }, // check box with check
-{ 0x002614, 0x002615 }, // umbrella with rain drops..hot beverage
-{ 0x002618, 0x002618 }, // shamrock
-{ 0x00261d, 0x00261d }, // index pointing up
-{ 0x002620, 0x002620 }, // skull and crossbones
-{ 0x002622, 0x002623 }, // radioactive..biohazard
-{ 0x002626, 0x002626 }, // orthodox cross
-{ 0x00262a, 0x00262a }, // star and crescent
-{ 0x00262e, 0x00262f }, // peace symbol
-{ 0x002638, 0x00263a }, // wheel of dharma..frowning face
-{ 0x002640, 0x002640 }, // female sign
-{ 0x002642, 0x002642 }, // male sign
-{ 0x002648, 0x002653 }, // Aries..Pisces
-{ 0x00265f, 0x002660 }, // chess pawn
-{ 0x002663, 0x002663 }, // club suit
-{ 0x002665, 0x002666 }, // heart suit..diamond suit
-{ 0x002668, 0x002668 }, // hot springs
-{ 0x00267b, 0x00267b }, // recycling symbol
-{ 0x00267e, 0x00267f }, // infinity
-{ 0x002692, 0x002697 }, // hammer and pick
-{ 0x002699, 0x002699 }, // gear
-{ 0x00269b, 0x00269c }, // atom symbol..fleur-de-lis
-{ 0x0026a0, 0x0026a1 }, // warning..high voltage
-{ 0x0026a7, 0x0026a7 }, // transgender symbol
-{ 0x0026aa, 0x0026ab }, // white circle..black circle
-{ 0x0026b0, 0x0026b1 }, // coffin..funeral urn
-{ 0x0026bd, 0x0026be }, // soccer ball..baseball
-{ 0x0026c4, 0x0026c5 }, // snowman without snow..sun behind cloud
-{ 0x0026c8, 0x0026c8 }, // cloud with lightning and rain
-{ 0x0026ce, 0x0026cf }, // Ophiuchus
-{ 0x0026d1, 0x0026d1 }, // rescue worker’s helmet
-{ 0x0026d3, 0x0026d4 }, // chains
-{ 0x0026e9, 0x0026ea }, // shinto shrine
-{ 0x0026f0, 0x0026f5 }, // mountain..umbrella on ground
-{ 0x0026f7, 0x0026fa }, // skier..person bouncing ball
-{ 0x0026fd, 0x0026fd }, // fuel pump
-{ 0x002702, 0x002702 }, // scissors
-{ 0x002705, 0x002705 }, // check mark button
-{ 0x002708, 0x00270d }, // airplane..victory hand
-{ 0x00270f, 0x00270f }, // pencil
-{ 0x002712, 0x002712 }, // black nib
+{ 0x002600, 0x002605 }, // sun..cloud
+{ 0x002607, 0x002612 }, // LIGHTNING..OPPOSITION
+{ 0x002614, 0x002685 }, // umbrella with rain drops..hot beverage
+{ 0x002690, 0x002705 }, // WHITE FLAG..BLACK FLAG
+{ 0x002708, 0x002712 }, // airplane..victory hand
 { 0x002714, 0x002714 }, // check mark
 { 0x002716, 0x002716 }, // multiply
 { 0x00271d, 0x00271d }, // latin cross
@@ -74,7 +37,7 @@
 { 0x00274e, 0x00274e }, // cross mark button
 { 0x002753, 0x002755 }, // red question mark..white exclamation mark
 { 0x002757, 0x002757 }, // red exclamation mark
-{ 0x002763, 0x002764 }, // heart exclamation
+{ 0x002763, 0x002767 }, // heart exclamation
 { 0x002795, 0x002797 }, // plus..divide
 { 0x0027a1, 0x0027a1 }, // right arrow
 { 0x0027b0, 0x0027b0 }, // curly loop
@@ -88,64 +51,31 @@
 { 0x00303d, 0x00303d }, // part alternation mark
 { 0x003297, 0x003297 }, // Japanese “congratulations” button
 { 0x003299, 0x003299 }, // Japanese “secret” button
-{ 0x01f004, 0x01f004 }, // mahjong red dragon
-{ 0x01f0cf, 0x01f0cf }, // joker
-{ 0x01f170, 0x01f171 }, // A button (blood type)..B button (blood type)
+{ 0x01f000, 0x01f0ff }, // MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
+{ 0x01f10d, 0x01f10f }, // CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+{ 0x01f12f, 0x01f12f }, // COPYLEFT SYMBOL
+{ 0x01f16c, 0x01f171 }, // RAISED MR SIGN..CIRCLED HUMAN FIGURE
 { 0x01f17e, 0x01f17f }, // O button (blood type)..P button
 { 0x01f18e, 0x01f18e }, // AB button (blood type)
 { 0x01f191, 0x01f19a }, // CL button..VS button
-{ 0x01f1e6, 0x01f1ff }, // regional indicator symbol letter a..regional indicator symbol letter z
-{ 0x01f201, 0x01f202 }, // Japanese “here” button..Japanese “service charge” button
+{ 0x01f1ad, 0x01f1e5 }, // MASK WORK SYMBOL..<reserved-1F1E5>
+{ 0x01f201, 0x01f20f }, // Japanese “here” button..Japanese “service charge” button
 { 0x01f21a, 0x01f21a }, // Japanese “free of charge” button
 { 0x01f22f, 0x01f22f }, // Japanese “reserved” button
 { 0x01f232, 0x01f23a }, // Japanese “prohibited” button..Japanese “open for business” button
-{ 0x01f250, 0x01f251 }, // Japanese “bargain” button..Japanese “acceptable” button
-{ 0x01f300, 0x01f321 }, // cyclone..milky way
-{ 0x01f324, 0x01f393 }, // sun behind small cloud..wind face
-{ 0x01f396, 0x01f397 }, // military medal..reminder ribbon
-{ 0x01f399, 0x01f39b }, // studio microphone..control knobs
-{ 0x01f39e, 0x01f3f0 }, // film frames..admission tickets
-{ 0x01f3f3, 0x01f3f5 }, // white flag
-{ 0x01f3f7, 0x01f4fd }, // label
-{ 0x01f4ff, 0x01f53d }, // prayer beads..repeat single button
-{ 0x01f549, 0x01f54e }, // om..dove
-{ 0x01f550, 0x01f567 }, // one o’clock..twelve o’clock
-{ 0x01f56f, 0x01f570 }, // candle..mantelpiece clock
-{ 0x01f573, 0x01f57a }, // hole..joystick
-{ 0x01f587, 0x01f587 }, // linked paperclips
-{ 0x01f58a, 0x01f58d }, // pen..crayon
-{ 0x01f590, 0x01f590 }, // hand with fingers splayed
-{ 0x01f595, 0x01f596 }, // middle finger..vulcan salute
-{ 0x01f5a4, 0x01f5a5 }, // black heart
-{ 0x01f5a8, 0x01f5a8 }, // printer
-{ 0x01f5b1, 0x01f5b2 }, // computer mouse..trackball
-{ 0x01f5bc, 0x01f5bc }, // framed picture
-{ 0x01f5c2, 0x01f5c4 }, // card index dividers..file cabinet
-{ 0x01f5d1, 0x01f5d3 }, // wastebasket..spiral calendar
-{ 0x01f5dc, 0x01f5de }, // clamp..rolled-up newspaper
-{ 0x01f5e1, 0x01f5e1 }, // dagger
-{ 0x01f5e3, 0x01f5e3 }, // speaking head
-{ 0x01f5e8, 0x01f5e8 }, // left speech bubble
-{ 0x01f5ef, 0x01f5ef }, // right anger bubble
-{ 0x01f5f3, 0x01f5f3 }, // ballot box with ballot
-{ 0x01f5fa, 0x01f64f }, // world map
-{ 0x01f680, 0x01f6c5 }, // rocket
-{ 0x01f6cb, 0x01f6d2 }, // couch and lamp
-{ 0x01f6d5, 0x01f6d7 }, // hindu temple
-{ 0x01f6dc, 0x01f6e5 }, // wireless
-{ 0x01f6e9, 0x01f6e9 }, // small airplane
-{ 0x01f6eb, 0x01f6ec }, // airplane departure..airplane arrival
-{ 0x01f6f0, 0x01f6f0 }, // satellite
-{ 0x01f6f3, 0x01f6fc }, // passenger ship
-{ 0x01f7e0, 0x01f7eb }, // orange circle..brown square
-{ 0x01f7f0, 0x01f7f0 }, // heavy equals sign
+{ 0x01f23c, 0x01f23f }, // <reserved-1F23C>..<reserved-1F23F>
+{ 0x01f249, 0x01f3fa }, // <reserved-1F249>..<reserved-1F24F>
+{ 0x01f400, 0x01f53d }, // rat..rabbit
+{ 0x01f546, 0x01f64f }, // WHITE LATIN CROSS..CELTIC CROSS
+{ 0x01f680, 0x01f6ff }, // rocket
+{ 0x01f774, 0x01f77f }, // LOT OF FORTUNE..ORCUS
+{ 0x01f7d5, 0x01f7ff }, // CIRCLED TRIANGLE..<reserved-1F7DF>
+{ 0x01f80c, 0x01f80f }, // <reserved-1F80C>..<reserved-1F80F>
+{ 0x01f848, 0x01f84f }, // <reserved-1F848>..<reserved-1F84F>
+{ 0x01f85a, 0x01f85f }, // <reserved-1F85A>..<reserved-1F85F>
+{ 0x01f888, 0x01f88f }, // <reserved-1F888>..<reserved-1F88F>
+{ 0x01f8ae, 0x01f8ff }, // <reserved-1F8AE>..<reserved-1F8FF>
 { 0x01f90c, 0x01f93a }, // pinched fingers
 { 0x01f93c, 0x01f945 }, // people wrestling..person playing handball
-{ 0x01f947, 0x01f9ff }, // 1st place medal..martial arts uniform
-{ 0x01fa70, 0x01fa7c }, // ballet shoes..shorts
-{ 0x01fa80, 0x01fa88 }, // yo-yo..parachute
-{ 0x01fa90, 0x01fabd }, // ringed planet..banjo
-{ 0x01fabf, 0x01fac5 }, // goose
-{ 0x01face, 0x01fadb }, // moose..donkey
-{ 0x01fae0, 0x01fae8 }, // melting face..bubbles
-{ 0x01faf0, 0x01faf8 }, // hand with index finger and thumb crossed..heart hands
+{ 0x01f947, 0x01faff }, // 1st place medal..martial arts uniform
+{ 0x01fc00, 0x01fffd }, // <reserved-1FC00>..<reserved-1FFFD>

--- a/tests/unicodebuf-text-emoji.txt
+++ b/tests/unicodebuf-text-emoji.txt
@@ -13,14 +13,16 @@
 🐱:U+1F431 CAT FACE
 👤:U+1F464 BUST IN SILHOUETTE
 🐱‍👤:U+1F431 + U+1F464 (Ninja Cat Windows 10+ only?)
--- Not Emoji + Neautral
-☻:U+263B  BLACK SMILING FACE
 -- Emoji + Half
 ない?
+-- Emoji(<U+1F000) + Ambiguous
+®:U+00AE REGISTERED SIGN
 -- Emoji(<U+1F000) + Neutral
 ©:U+00A9 COPYRIGHT SIGN
+☇:U+2607 LIGHTNING
 ☹:U+2639 WHITE FROWNING FACE
-☺:U+263A White Smiling Face
+☺:U+263A WHITE SMILING FACE
+☻:U+263B BLACK SMILING FACE
 ❤:U+2764 HEAVY BLACK HEART
 -- Emoji(>=U+1F000) + Neutral
 🏎:U+1F3CE racing car


### PR DESCRIPTION
絵文字テーブルを変更します。

テストしていて2cellのほうが自然そうだけど、
Override Emoji Characters width = 2にしても
1cellで表示される文字を見つけました。

例

☇:U+2607 LIGHTNING
☻:U+263B BLACK SMILING FACE

  webブラウザでの文字の見え方は選択したフォントによると思います。
  Tera Term上などで次のコマンドで見え方をチェックできます。

```
wget https://raw.githubusercontent.com/TeraTermProject/teraterm/emoji_width/tests/unicodebuf-text-emoji.txt -O -
```

絵文字の種類(=属性, Properties)が6種あって、
https://www.unicode.org/reports/tr51/#Emoji_Properties_and_Data_Files
現在はEmoji属性の文字を絵文字としています。
これよりもExtended_Pictographic属性を使ったほうがよさそうです。
それなら上記文字も2cellで表示することがでるようになります。

Unicodeにしかない(Shift_JIS(CP932) などにはない)絵文字の
文字幅はどうしたものかなと思うのですが
2cell(全角)のほうが違和感がない印象です。
将来絵文字属性によって文字幅を変えたい、となるかもしれないですね。

Unicodeの文字幅の説明にも手を入れました。

特に指摘などなさそうでしたら2,3日でマージしようと思います。
