### PR TITLE
/V オプション指定時、不正な処理で終了しないよう修正 #191

### DIFF
--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -454,6 +454,20 @@ CVTWindow::CVTWindow(HINSTANCE hInstance)
 	/* Enable drag-drop */
 	::DragAcceptFiles(HVTWin,TRUE);
 
+	DropInit();
+	DropLists = NULL;
+	DropListCount = 0;
+
+#if UNICODE_DEBUG
+	CtrlKeyState = 0;
+#endif
+
+	// TipWin
+	if (ts.HideWindow==0) {
+		TipWin = new CTipWin(hInstance);
+		TipWin->Create(HVTWin);
+	}
+
 	if (ts.HideWindow>0) {
 		if (strlen(TopicName)>0) {
 			InitDDE();
@@ -470,20 +484,6 @@ CVTWindow::CVTWindow(HINSTANCE hInstance)
 	SetWindowAlpha(ts.AlphaBlendActive);
 	ShowWindow(CmdShow);
 	ChangeCaret();
-
-	DropInit();
-	DropLists = NULL;
-	DropListCount = 0;
-
-#if UNICODE_DEBUG
-	CtrlKeyState = 0;
-#endif
-
-	// TipWin
-	if (ts.HideWindow==0) {
-		TipWin = new CTipWin(hInstance);
-		TipWin->Create(HVTWin);
-	}
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- 初期化されない不定な変数があり、終了時 free() しようとして不正な処理が発生
- #160 と現象は同様なため改修履歴は省略
  - 6491bf2