### PR TITLE
追加の認証情報が必要なSSHログインに対応した

### DIFF
--- a/installer/release/lang_utf8/Japanese.lng
+++ b/installer/release/lang_utf8/Japanese.lng
@@ -1,4 +1,4 @@
-﻿; Updated by TeraTerm Project (2024-03-30)
+﻿; Updated by TeraTerm Project (2024-04-07)
 
 [Tera Term]
 DLG_SYSTEM_FONT=ＭＳ Ｐゴシック,12,128
@@ -645,6 +645,7 @@ DLG_AUTH_TITLE_FAILED=SSH認証を再試行中
 DLG_AUTH_BANNER=ログイン中: %s
 DLG_AUTH_BANNER2=認証が必要です.
 DLG_AUTH_BANNER2_FAILED=認証に失敗しました. 再試行してください.
+DLG_AUTH_BANNER2_FURTHER=追加の認証が必要です
 DLG_AUTH_USERNAME=ユーザ名(&N):
 DLG_AUTH_USE_DEFAULT_USERNAME=デフォルトユーザ名を使用(&D)
 DLG_AUTH_USE_LOGON_USERNAME=ログオンユーザ名を使用(&L)

--- a/ttssh2/ttxssh/auth.h
+++ b/ttssh2/ttxssh/auth.h
@@ -50,6 +50,8 @@ typedef struct {
   char *user;
   AUTHCred cur_cred;
   SSHAuthMethod failed_method;
+  SSHAuthMethod initial_method;
+  int partial_success;
   int flags;
   int supported_types;
   HWND auth_dialog;

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -4857,14 +4857,14 @@ static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
 
 			// パスワードを覚えている場合のみ、コマンドラインに渡す。(2006.8.3 yutaka)
 			if (pvar->settings.remember_password &&
-			    pvar->auth_state.cur_cred.method == SSH_AUTH_PASSWORD) {
+			    pvar->auth_state.initial_method == SSH_AUTH_PASSWORD) {
 				dquote_string(pvar->auth_state.cur_cred.password, mark, sizeof(mark));
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
 							 L" /auth=password /user=%hs /passwd=%hs", pvar->auth_state.user, mark);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
 			} else if (pvar->settings.remember_password &&
-			           pvar->auth_state.cur_cred.method == SSH_AUTH_RSA) {
+			           pvar->auth_state.initial_method == SSH_AUTH_RSA) {
 				wchar_t markW[MAX_PATH];
 				dquote_string(pvar->auth_state.cur_cred.password, mark, sizeof(mark));
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
@@ -4876,13 +4876,13 @@ static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
 			} else if (pvar->settings.remember_password &&
-			           pvar->auth_state.cur_cred.method == SSH_AUTH_TIS) {
+			           pvar->auth_state.initial_method == SSH_AUTH_TIS) {
 				dquote_string(pvar->auth_state.cur_cred.password, mark, sizeof(mark));
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
 							 L" /auth=challenge /user=%hs /passwd=%hs", pvar->auth_state.user, mark);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
-			} else if (pvar->auth_state.cur_cred.method == SSH_AUTH_PAGEANT) {
+			} else if (pvar->auth_state.initial_method == SSH_AUTH_PAGEANT) {
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
 							 L" /auth=pageant /user=%hs", pvar->auth_state.user);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);


### PR DESCRIPTION
## 現状
- Tera Termは、Google Authenticator PAMモジュールなどによる二要素認証(TOTPなど)に対応していない
- PuTTYやOpenSSHでは二要素認証が利用できるので、Tera Termでも対応したい

## 対応
- 追加の認証情報の要求に対応しました
  - SSHサーバにGoogle AuthenticatorのPAMモジュールを組み込んでTOTPによる二要素認証などに対応します
  - 追加認証を要する場合には、autologinは無効になります（セッション複製時も含む）
- 追加認証を求められたときの日本語メッセージを追加しました
### 変更の概要
- SSHの接続で、SSH_MSG_USERAUTH_FAILURE に一部成功(partial success)フラグが含まれるとき、追加の認証を求めるダイアログに遷移します
- 一部成功フラグが含まれる場合は追加の認証情報の入力が必要となるため、自動ログイン(autologin)が無効になります
- セッションの複製に使用するため、一部成功の有無と初回の認証メソッドを保持する構造体変数を追加しました
### 動作イメージ
- PR元コミットのコメントに記載しました。
- https://github.com/yasu-hide/teratermproject_teraterm/commit/9e72cc0968f49ffd0315b3a7dbd214861db9413b#commitcomment-140706183