### PR TITLE
basename, dirname で文字列をUnicodeとして扱うようにした #217

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -83,9 +83,10 @@
       <li>Fixed wrong characters were sent when transmit character code is JIS.
         <ul>
           <li>Fixed wrong character output at end of line.</li>
-          <li>Fixed wrong character output when local echo is on.<li>
+          <li>Fixed wrong character output when local echo is on.</li>
         </ul>
       </li>
+      <li>MACRO: Fixed path of <a href="../macro/command/basename.html">basename</a> and <a href="../macro/command/dirname.html">dirname</a> macro commands were not Unicode-compatible.</li>
     </ul>
   </li>
 

--- a/doc/en/html/macro/command/dirname.html
+++ b/doc/en/html/macro/command/dirname.html
@@ -41,7 +41,7 @@ dirname dir 'c:\teraterm'
 
 <h2>See also</h2>
 <ul>
-  <li><a href="basename.html">dirname</a></li>
+  <li><a href="basename.html">basename</a></li>
   <li><a href="makepath.html">makepath</a></li>
 </ul>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -86,6 +86,7 @@
           <li>ローカルエコーがON時、正しくエコーされなかったので修正</li>
         </ul>
       </li>
+      <li>MACRO: <a href="../macro/command/basename.html">basename</a>, <a href="../macro/command/dirname.html">dirname</a>マクロコマンドのパスがUnicodeに対応していなかったので修正した。</li>
     </ul>
   </li>
 

--- a/doc/ja/html/macro/command/dirname.html
+++ b/doc/ja/html/macro/command/dirname.html
@@ -41,7 +41,7 @@ dirname dir 'c:\teraterm'
 
 <h2>QÆ</h2>
 <ul>
-  <li><a href="basename.html">dirname</a></li>
+  <li><a href="basename.html">basename</a></li>
   <li><a href="makepath.html">makepath</a></li>
 </ul>
 

--- a/teraterm/common/codeconv.cpp
+++ b/teraterm/common/codeconv.cpp
@@ -974,10 +974,16 @@ char32_t *_WideCharToUTF32(const wchar_t *wstr_ptr, size_t wstr_len, size_t *u32
  *							(NULLのとき文字列長を返さない)
  *	@retval		wchar_t文字列へのポインタ(NULLの時変換エラー)
  *				使用後 free() すること
+ *
+ *				変換できない文字が入力された場合
+ *					Vista以降
+ *						U+FFFD に置き換えられる
+ *					2000 SP4,XP以降
+ *						文字を削除する
  */
 wchar_t *_MultiByteToWideChar(const char *str_ptr, size_t str_len, int code_page, size_t *w_len_)
 {
-	DWORD flags = MB_ERR_INVALID_CHARS;
+	DWORD flags = MB_PRECOMPOSED;
 	if (code_page == CP_ACP) {
 		code_page = (int)GetACP();
 	}


### PR DESCRIPTION
- 修正前はANSI文字列として扱っていた
- ファイル名の取り扱い部分の文字長制限をなくした
  - MAX_PATH など文字長定数を使用しない
  - _splitpath_s() を使用をやめた
- codeconv.cpp の _MultiByteToWideChar() で変換できない文字が入力された場合の動作を変更
  - 従来は変換エラーとなり、NULLを返していた
  - 変更後 U+FFFD に置換、または、その文字を削除
  - ToCharU8(), ToWcharA(), ToWcharU8(), ToU8A() も影響を受ける
  - U+FFFD replacement character
    - 不明な文字、認識できない文字、表現できない文字を置き換えるために使用される