### PR TITLE
sendマクロコマンドで送信したデータが異なったものにならないよう修正 #215

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -65,6 +65,7 @@
       <li>Download folder setting is moved to <a href="../menu/setup-additional-general.html#DownloadFolder">General tab</a> of Additional settings dialog.</li>
       <li>Modified to <a href="../setup/teraterm-ssh.html#AuthBanner">display SSH authentication banner in VT window</a> regardless of receiving character code.
       <li>Keyboard setting dialog is moved to Keyboard tab of Additional setting dialog.</li>
+      <li>MACRO: <a href="../macro/command/send.html">send</a> macro command check data and sends it as text or binary. added <a href="../macro/command/sendtext.html">sendtext</a> and <a href="../macro/command/sendbinary.html">sendbinary</a> macro command</li>
     </ul>
   </li>
 

--- a/doc/en/html/macro/command/index.html
+++ b/doc/en/html/macro/command/index.html
@@ -54,6 +54,7 @@ Command index
  <li><a href="scprecv.html">scprecv</a> (version 4.57 or later)
  <li><a href="scpsend.html">scpsend</a> (version 4.57 or later)
  <li><a href="send.html">send</a>
+ <li><a href="sendbinary.html">sendbinary</a> (version 5.3 or later)
  <li><a href="sendbreak.html">sendbreak</a>
  <li><a href="sendbroadcast.html">sendbroadcast</a> (version 4.62 or later)
  <li><a href="sendfile.html">sendfile</a>
@@ -61,6 +62,7 @@ Command index
  <li><a href="sendln.html">sendln</a>
  <li><a href="sendlnbroadcast.html">sendlnbroadcast</a> (version 4.62 or later)
  <li><a href="sendlnmulticast.html">sendlnmulticast</a> (version 4.96 or later)
+ <li><a href="sendtext.html">sendtext</a> (version 5.3 or later)
  <li><a href="sendmulticast.html">sendmulticast</a> (version 4.62 or later)
  <li><a href="setbaud.html">setbaud</a> (version 4.58 or later)
  <li><a href="setdebug.html">setdebug</a> (version 4.64 or later)

--- a/doc/en/html/macro/command/send.html
+++ b/doc/en/html/macro/command/send.html
@@ -29,6 +29,10 @@ If &lt;data&gt; is a string, the string is sent to the host. <br>
 If &lt;data&gt; is an integer, its lowest-order byte (0-255) is regarded as an ASCII code of the character, and the character is sent to the host.
 </p>
 
+<p>
+  The datas are checked, and when data is judged to be text, data is sent in same as "<a href="sendtext.html">sendtext</a>"; when data is judged to be binary, data is sent in same as "<a href="sendbinary.html">sendbinary</a>".
+<p>
+
 <h2>Example</h2>
 
 <pre class="macro-example">
@@ -73,6 +77,8 @@ See also "<a href="setsync.html">setsync</a>" for the synchronous mode.
 <h2>See also</h2>
 <ul>
   <li><a href="sendln.html">sendln</a></li>
+  <li><a href="sendtext.html">sendtext</a></li>
+  <li><a href="sendbinary.html">sendbinary</a></li>
   <li><a href="../syntax/formats.html">Formats of constants</a></li>
 </ul>
 

--- a/doc/en/html/macro/command/sendbinary.html
+++ b/doc/en/html/macro/command/sendbinary.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+  "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <title>sendbinary</title>
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <link rel="stylesheet" href="../../style.css" type="text/css">
+</head>
+
+<body>
+
+
+<h1>sendbinary</h1>
+
+<p>
+Sends binary data. <em>(version 5.3 or lator)</em>
+</p>
+
+<pre class="macro-syntax">
+sendbinary &lt;data1&gt; &lt;data2&gt;....
+</pre>
+
+<h2>Remarks</h2>
+
+<p>
+Causes Tera Term to send characters to the host.<br>
+If &lt;data&gt; is a string, the string is sent to the host. <br>
+If &lt;data&gt; is an integer, its lowest-order byte (0-255) is regarded as an ASCII code of the character, and the character is sent to the host.
+</p>
+
+<p>
+  Data sent by ttpmacro.exe is received by ttermpro.exe and sent as is. Character encoding of the string type is UTF-8, strings are sent in UTF-8. Use g<a href="sendtext.html">sendtext</a>h to convert character code.
+</p>
+
+<h2>See also</h2>
+<ul>
+  <li><a href="send.html">send</a></li>
+  <li><a href="sendln.html">sendln</a></li>
+  <li><a href="sendtext.html">sendtext</a></li>
+  <li><a href="../syntax/formats.html">Formats of constants</a></li>
+</ul>
+
+</body>
+</html>

--- a/doc/en/html/macro/command/sendtext.html
+++ b/doc/en/html/macro/command/sendtext.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+  "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <title>sendtext</title>
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <link rel="stylesheet" href="../../style.css" type="text/css">
+</head>
+
+<body>
+
+
+<h1>sendtext</h1>
+
+<p>
+Sends text data. <em>(Version 5.3 or lator)</em>
+</p>
+
+<pre class="macro-syntax">
+sendtext &lt;data1&gt; &lt;data2&gt;....
+</pre>
+
+<h2>Remarks</h2>
+
+<p>
+Causes Tera Term to send characters to the host.<br>
+If &lt;data&gt; is a string, the string is sent to the host. <br>
+If &lt;data&gt; is an integer, its lowest-order byte (0-255) is regarded as an ASCII code of the character, and the character is sent to the host.
+</p>
+
+<p>
+  String sent by ttpmacro.exe is received by ttermpro.exe, converted to character code and sent. Use "<a href="sendbinary.html">sendbinary</a>" to send without conversion.
+</p>
+
+<h2>See also</h2>
+<ul>
+  <li><a href="sendbinary.html">sendbinary</a></li>
+  <li><a href="send.html">send</a></li>
+  <li><a href="../syntax/formats.html">Formats of constants</a></li>
+</ul>
+
+</body>
+</html>

--- a/doc/en/teraterm.hhc
+++ b/doc/en/teraterm.hhc
@@ -1048,6 +1048,11 @@
 					<param name="ImageNumber" value="11">
 					</OBJECT>
 				<LI> <OBJECT type="text/sitemap">
+					<param name="Name" value="sendbinary">
+					<param name="Local" value="html\macro\command\sendbinary.html">
+					<param name="ImageNumber" value="11">
+					</OBJECT>
+				<LI> <OBJECT type="text/sitemap">
 					<param name="Name" value="sendbreak">
 					<param name="Local" value="html\macro\command\sendbreak.html">
 					<param name="ImageNumber" value="11">
@@ -1085,6 +1090,11 @@
 				<LI> <OBJECT type="text/sitemap">
 					<param name="Name" value="sendmulticast">
 					<param name="Local" value="html\macro\command\sendmulticast.html">
+					<param name="ImageNumber" value="11">
+					</OBJECT>
+				<LI> <OBJECT type="text/sitemap">
+					<param name="Name" value="sendtext">
+					<param name="Local" value="html\macro\command\sendtext.html">
 					<param name="ImageNumber" value="11">
 					</OBJECT>
 				<LI> <OBJECT type="text/sitemap">

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -65,6 +65,7 @@
       <li>ダウンロードフォルダの設定を Additional settings の <a href="../menu/setup-additional-general.html#DownloadFolder">General タブ</a>へ移動した。</li>
       <li><a href="../setup/teraterm-ssh.html#AuthBanner">SSH認証バナーをVT ウィンドウ内に表示する</a>時、受信文字コードによらず表示できるよう変更した。</li>
       <li>キーボード設定ダイアログを Additional settings の Keyboard タブへ移動した。</li>
+      <li>MACRO: <a href="../macro/command/send.html">send</a> マクロコマンドは送信データを判定してテキスト又はバイナリとして送信する。<a href="../macro/command/sendtext.html">sendtext</a> と <a href="../macro/command/sendbinary.html">sendbinary</a> マクロコマンドを追加した。</li>
     </ul>
   </li>
 

--- a/doc/ja/html/macro/command/index.html
+++ b/doc/ja/html/macro/command/index.html
@@ -54,6 +54,7 @@
  <li><a href="scprecv.html">scprecv</a> (バージョン 4.57以降)
  <li><a href="scpsend.html">scpsend</a> (バージョン 4.57以降)
  <li><a href="send.html">send</a>
+ <li><a href="sendbinary.html">sendbinary</a> (バージョン 5.3以降)
  <li><a href="sendbreak.html">sendbreak</a>
  <li><a href="sendbroadcast.html">sendbroadcast</a> (バージョン 4.62以降)
  <li><a href="sendfile.html">sendfile</a>
@@ -61,6 +62,7 @@
  <li><a href="sendln.html">sendln</a>
  <li><a href="sendlnbroadcast.html">sendlnbroadcast</a> (バージョン 4.62以降)
  <li><a href="sendlnmulticast.html">sendlnmulticast</a> (バージョン 4.96以降)
+ <li><a href="sendtext.html">sendtext</a> (バージョン 5.3以降)
  <li><a href="sendmulticast.html">sendmulticast</a> (バージョン 4.62以降)
  <li><a href="setbaud.html">setbaud</a> (バージョン 4.58以降)
  <li><a href="setdebug.html">setdebug</a> (バージョン 4.64以降)

--- a/doc/ja/html/macro/command/send.html
+++ b/doc/ja/html/macro/command/send.html
@@ -28,6 +28,10 @@ send &lt;data1&gt; &lt;data2&gt;....
 &lt;data&gt; が整数型の場合は、その値の下位バイト(0-255)を ASCII コードとみなし、その文字を送信させる。
 </p>
 
+<p>
+  送信データは内容を判定して、文字と判定した場合 "<a href="sendtext.html">sendtext</a>" と同様に送信、バイナリと判定した場合 "<a href="sendbinary.html">sendbinary</a>" と同様に送信する。
+<p>
+
 <h2>例</h2>
 
 <pre class="macro-example">
@@ -72,6 +76,8 @@ send #9
 <h2>参照</h2>
 <ul>
   <li><a href="sendln.html">sendln</a></li>
+  <li><a href="sendtext.html">sendtext</a></li>
+  <li><a href="sendbinary.html">sendbinary</a></li>
   <li><a href="../syntax/formats.html">定数の形式</a></li>
 </ul>
 

--- a/doc/ja/html/macro/command/sendbinary.html
+++ b/doc/ja/html/macro/command/sendbinary.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+  "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+  <title>sendbinary</title>
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <link rel="stylesheet" href="../../style.css" type="text/css">
+</head>
+
+<body>
+
+
+<h1>sendbinary</h1>
+
+<p>
+バイナリを送信する。 <em>(バージョン 5.3以降)</em>
+</p>
+
+<pre class="macro-syntax">
+sendbinary &lt;data1&gt; &lt;data2&gt;....
+</pre>
+
+<h2>解説</h2>
+
+<p>
+&lt;data&gt; が文字列型の場合、文字列をホストへ送信させる。<br>
+&lt;data&gt; が整数型の場合は、その値の下位バイト(0-255)を ASCII コードとみなし、その文字を送信する。
+</p>
+
+<p>
+  ttpmacro.exe が送信したデータは、ttermpro.exe が受信して、そのまま送信する。文字列型の文字コードはUTF-8なので、文字列はUTF-8で送信される。文字コードを変換する場合は "<a href="sendtext.html">sendtext</a>" を使用する。
+</p>
+
+<h2>参照</h2>
+<ul>
+  <li><a href="send.html">send</a></li>
+  <li><a href="sendln.html">sendln</a></li>
+  <li><a href="sendtext.html">sendtext</a></li>
+  <li><a href="../syntax/formats.html">定数の形式</a></li>
+</ul>
+
+</body>
+</html>

--- a/doc/ja/html/macro/command/sendtext.html
+++ b/doc/ja/html/macro/command/sendtext.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+  "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+  <title>sendtext</title>
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <link rel="stylesheet" href="../../style.css" type="text/css">
+</head>
+
+<body>
+
+
+<h1>sendtext</h1>
+
+<p>
+テキストを送信する。 <em>(バージョン 5.3以降)</em>
+</p>
+
+<pre class="macro-syntax">
+sendtext &lt;data1&gt; &lt;data2&gt;....
+</pre>
+
+<h2>解説</h2>
+
+<p>
+&lt;data&gt; が文字列型の場合、文字列をホストへ送信させる。<br>
+&lt;data&gt; が整数型の場合は、その値の下位バイト(0-255)を ASCII コードとみなし、その文字を送信する。
+</p>
+
+<p>
+  ttpmacro.exeが送信した文字列は、ttermpro.exe が受信して、設定された文字コードに変換して送信する。変換せずに送信する場合は "<a href="sendbinary.html">sendbinary</a>" を使用する。
+</p>
+
+<h2>参照</h2>
+<ul>
+  <li><a href="sendbinary.html">sendbinary</a></li>
+  <li><a href="send.html">send</a></li>
+  <li><a href="../syntax/formats.html">定数の形式</a></li>
+</ul>
+
+</body>
+</html>

--- a/doc/ja/html/reference/dev/macro_proto.md
+++ b/doc/ja/html/reference/dev/macro_proto.md
@@ -1,0 +1,49 @@
+﻿
+# Macro Protocol
+
+## XTYP_EXECUTE
+
+- command
+  - command definitions are in[teraterm/common/ttddecmnd.h](https://github.com/TeraTermProject/teraterm/blob/c7ce43608e0e2844e148b88cfadb9a96cebaba01/teraterm/common/ttddecmnd.h#L31)
+- ttpmacro -> ttermpro
+- packet length limit is MaxStrLen
+
+| pos | len | Description |
+|-----|-----|-------------|
+| 0   | 1   | command     |
+|     | N   | data        |
+
+- command (CmdSendUTF8String/CmdSendBinary/CmdSendCompatString)
+
+| pos | len | Description            |
+|-----|-----|------------------------|
+| 0   | 1   | command                |
+| 1   | 4   | length(little endian)  |
+| 5   | N   | data(string or binary) |
+
+
+## XTYP_POKE
+
+- data(text and binary)
+- ttpmacro -> ttermpro
+
+## XTYP_REQUEST
+
+- ttpmacro <- ttermpro
+  - Item "DATA"
+    - text or binary
+  - Item "PARAM"
+    - ファイル名的な?
+    - 通信の応答
+
+
+## DDE(DDEML) WIN32 APIs
+
+- DdeAccessData()
+  - ハンドル(HDDEDATA)から先頭のポインタとサイズを取得できる
+- DdeUnaccessData()
+  - DdeAccessData() した物を解除する
+- DdeGetData()
+  - ハンドル(HDDEDATA)のデータをワークにコピーする
+  - 戻り値が実際のサイズ
+

--- a/doc/ja/teraterm.hhc
+++ b/doc/ja/teraterm.hhc
@@ -1087,6 +1087,11 @@
 					<param name="ImageNumber" value="11">
 					</OBJECT>
 				<LI> <OBJECT type="text/sitemap">
+					<param name="Name" value="sendbinary">
+					<param name="Local" value="html\macro\command\sendbinary.html">
+					<param name="ImageNumber" value="11">
+					</OBJECT>
+				<LI> <OBJECT type="text/sitemap">
 					<param name="Name" value="sendbreak">
 					<param name="Local" value="html\macro\command\sendbreak.html">
 					<param name="ImageNumber" value="11">
@@ -1124,6 +1129,11 @@
 				<LI> <OBJECT type="text/sitemap">
 					<param name="Name" value="sendmulticast">
 					<param name="Local" value="html\macro\command\sendmulticast.html">
+					<param name="ImageNumber" value="11">
+					</OBJECT>
+				<LI> <OBJECT type="text/sitemap">
+					<param name="Name" value="sendtext">
+					<param name="Local" value="html\macro\command\sendtext.html">
 					<param name="ImageNumber" value="11">
 					</OBJECT>
 				<LI> <OBJECT type="text/sitemap">

--- a/teraterm/common/CMakeLists.txt
+++ b/teraterm/common/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(
   compat_win.h
   comportinfo.cpp
   comportinfo.h
+  ddelib.cpp
+  ddelib.h
   dlglib.c
   dlglib.h
   dlglib_cpp.cpp
@@ -66,7 +68,7 @@ add_library(
   tttext.h
   win32helper.cpp
   win32helper.h
-  )
+)
 
 target_include_directories(
   ${PACKAGE_NAME}

--- a/teraterm/common/common_static.v16.vcxproj
+++ b/teraterm/common/common_static.v16.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="asprintf.cpp" />
     <ClCompile Include="codeconv_mb.cpp" />
     <ClCompile Include="comportinfo.cpp" />
+    <ClCompile Include="ddelib.cpp" />
     <ClCompile Include="dlglib.c" />
     <ClCompile Include="dlglib_cpp.cpp" />
     <ClCompile Include="dlglib_tmpl.cpp" />
@@ -171,6 +172,7 @@
     <ClInclude Include="asprintf.h" />
     <ClInclude Include="codeconv_mb.h" />
     <ClInclude Include="comportinfo.h" />
+    <ClInclude Include="ddelib.h" />
     <ClInclude Include="dlglib.h" />
     <ClInclude Include="fileread.h" />
     <ClInclude Include="inifile_com.h" />

--- a/teraterm/common/common_static.v17.vcxproj
+++ b/teraterm/common/common_static.v17.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="asprintf.cpp" />
     <ClCompile Include="codeconv_mb.cpp" />
     <ClCompile Include="comportinfo.cpp" />
+    <ClCompile Include="ddelib.cpp" />
     <ClCompile Include="dlglib.c" />
     <ClCompile Include="dlglib_cpp.cpp" />
     <ClCompile Include="dlglib_tmpl.cpp" />
@@ -171,6 +172,7 @@
     <ClInclude Include="asprintf.h" />
     <ClInclude Include="codeconv_mb.h" />
     <ClInclude Include="comportinfo.h" />
+    <ClInclude Include="ddelib.h" />
     <ClInclude Include="dlglib.h" />
     <ClInclude Include="fileread.h" />
     <ClInclude Include="inifile_com.h" />

--- a/teraterm/common/ddelib.cpp
+++ b/teraterm/common/ddelib.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 1994-1998 T. Teranishi
+ * (C) 2024- TeraTerm Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ddelib.h"
+
+/**
+ *	DDE用 バイナリエンコード
+ *	DDE通信できるようバイナリをエスケープされたバイナリにエンコードする
+ *
+ *	0x00 -> 0x01 + 0x01
+ *	0x01 -> 0x01 + 0x02
+ *
+ *	@param[in]	src			入力バイナリ ptr
+ *	@param[in]	sec_len		入力バイナリ長
+ *	@param[out]	dest_len	出力バイナリ(エンコード済み)長
+ *	@return					出力バイナリ(エンコード済み)ptr,不要になったらfree()する
+ */
+uint8_t *EncodeDDEBinary(const uint8_t *src, size_t src_len, size_t *dest_len)
+{
+	uint8_t *d = (uint8_t *)malloc(src_len * 2);	// 最大2倍のデータ長
+	if (d == NULL) {
+		*dest_len = 0;
+		return NULL;
+	}
+	uint8_t *p = d;
+	size_t i;
+	size_t dlen = 0;
+	for (i = 0; i < src_len; i++) {
+		const uint8_t c = *src++;
+		if (c <= 0x01) {
+			*p++ = 0x01;
+			*p++ = c + 1;
+			dlen += 2;
+		}
+		else {
+			*p++ = c;
+			dlen++;
+		}
+	}
+	*dest_len = dlen;
+	return d;
+}
+
+/**
+ *	DDE用 バイナリデコード
+ *	DDE通信できるようエスケープされたバイナリをデコードする
+ *
+ *	0x01 + (x+1) -> x
+ *
+ *	@param[in]	src			入力バイナリ ptr
+ *	@param[in]	sec_len		入力バイナリ長
+ *	@param[out]	dest_len	出力バイナリ(デコード済み)長
+ *	@return					出力バイナリ(デコード済み)ptr,不要になったらfree()する
+ */
+uint8_t *DecodeDDEBinary(const uint8_t *src, size_t src_len, size_t *dest_len)
+{
+	uint8_t *d = (uint8_t *)malloc(src_len);
+	if (d == NULL) {
+		*dest_len = 0;
+		return NULL;
+	}
+	uint8_t *p = d;
+	size_t i;
+	size_t dlen = 0;
+	for (i = 0; i < src_len; i++) {
+		if (*src == 0x01) {
+			src++;
+			*p++ = (*src++) - 1;
+			i++;
+		}
+		else {
+			*p++ = *src++;
+		}
+		dlen++;
+	}
+	*dest_len = dlen;
+	return d;
+}

--- a/teraterm/common/ddelib.h
+++ b/teraterm/common/ddelib.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1994-1998 T. Teranishi
- * (C) 2005- TeraTerm Project
+ * (C) 2024- TeraTerm Project
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,66 +27,17 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* TTMACRO.EXE, DDE routines */
+#pragma once
 
-#include "ttddecmnd.h"
+#include <stdlib.h>	// for size_t
+#include <stdint.h>	// for uint8_t
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void Word2HexStr(WORD w, PCHAR HexStr);
-BOOL InitDDE(HWND HWin);
-void EndDDE();
-void DDEOut1Byte(BYTE B);
-void DDEOut(const char *B);
-void DDESend();
-void DDESendStringU8(const char *strU8);
-void DDESendBinary(const void *ptr, size_t len);
-PCHAR GetRecvLnBuff();
-void FlushRecv();
-void ClearWait();
-void SetWait(int Index, const char *Str);
-void ClearWaitN();
-void SetWaitN(int Len);
-int CmpWait(int Index, PCHAR Str);
-void SetWait2(PCHAR Str, int Len, int Pos);
-int Wait();
-BOOL Wait2();
-BOOL WaitN();
-int Wait4all();
-void SetFile(const char *filenameU8);
-void SetSecondFile(const char *filenameU8);
-void SetBinary(int BinFlag);
-void SetDebug(int DebugFlag);
-void SetLogOption(int *LogFlags);
-void SetXOption(int XOption);
-void SendSync();
-void SetSync(BOOL OnFlag);
-WORD SendCmnd(char OpId, int WaitFlag);
-WORD GetTTParam(char OpId, PCHAR Param, int destlen);
-int FindRegexStringOne(char *regex, int regex_len, char *target, int target_len);
-
-extern BOOL Linked;
-extern WORD ComReady;
-extern int OutLen;
-
-  // for "WaitRecv" command
-extern TStrVal Wait2Str;
-extern BOOL    Wait2Found;
-
-enum regex_type {
-	REGEX_NONE,
-	REGEX_WAIT,
-	REGEX_WAITLN,
-	REGEX_WAITRECV,
-	REGEX_WAITEVENT,
-};
-extern enum regex_type RegexActionType;
-
-extern BOOL Wait4allGotIndex;
-extern int Wait4allFoundNum;
-
+uint8_t *EncodeDDEBinary(const uint8_t *src, size_t src_len, size_t *dest_len);
+uint8_t *DecodeDDEBinary(const uint8_t *src, size_t src_len, size_t *dest_len);
 
 #ifdef __cplusplus
 }

--- a/teraterm/common/ttddecmnd.h
+++ b/teraterm/common/ttddecmnd.h
@@ -88,6 +88,9 @@
 #define CmdLogAutoClose     'X'
 #define CmdGetModemStatus   'Y'
 #define CmdSetFlowCtrl      'Z'
+#define CmdSendUTF8String   'a'
+#define CmdSendBinary       'b'
+#define CmdSendCompatString 'c'	// ]—ˆ‚Ì•¶š‘—M‚ÆŒİŠ·, String‚©Binary‚©”»’è•K—v
 
 #define LogOptBinary        1
 #define LogOptAppend        2

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -34,6 +34,9 @@
 #include <ddeml.h>
 #include <stdint.h>
 #include <assert.h>
+#define _CRTDBG_MAP_ALLOC
+#include <stdlib.h>
+#include <crtdbg.h>
 
 #include "teraterm.h"
 #include "tttypes.h"
@@ -56,6 +59,7 @@
 #include "asprintf.h"
 #include "vtterm.h"
 #include "ttcstd.h"
+#include "ddelib.h"
 
 #define ServiceName "TERATERM"
 #define ItemName "DATA"
@@ -294,9 +298,10 @@ static HDDEDATA AcceptRequest(HSZ ItemHSz)
 
 	if ((! DDELog) || (ConvH==0)) return 0;
 
-	if (DdeCmpStringHandles(ItemHSz, Item2) == 0) // item "PARAM"
+	if (DdeCmpStringHandles(ItemHSz, Item2) == 0) { // item "PARAM"
 		DH = DdeCreateDataHandle(Inst,ParamFileName,sizeof(ParamFileName),0,
 		                         Item2,CF_OEMTEXT,0);
+	}
 	else if (DdeCmpStringHandles(ItemHSz, Item) == 0) // item "DATA"
 	{
 		Len = DDEGetDataLen();
@@ -331,35 +336,11 @@ static HDDEDATA AcceptRequest(HSZ ItemHSz)
 			DdeUnaccessData(DH);
 		}
 	}
-	else
+	else {
 		return 0;
+	}
 
 	return DH;
-}
-
-/**
- *	エスケープされたバイナリをデコードする
- *	0x01 + (x+1) -> x
- */
-static uint8_t *DecodeEscape(const uint8_t *src, size_t src_len, size_t *dest_len)
-{
-	uint8_t *dest = (uint8_t *)malloc(src_len);
-	uint8_t *p = dest;
-	size_t i;
-	size_t dlen = 0;
-	for (i = 0; i < src_len; i++) {
-		if (*src == 0x01) {
-			src++;
-			*p++ = (*src++) - 1;
-			i++;
-		}
-		else {
-			*p++ = *src++;
-		}
-		dlen++;
-	}
-	*dest_len = dlen;
-	return dest;
 }
 
 /**
@@ -385,6 +366,87 @@ static BOOL IsBinaryData(const uint8_t *data, size_t len)
 	return FALSE;
 }
 
+static void SendData(const char *DataPtr, DWORD DataSize)
+{
+	// マクロコマンド "send" で送信すると、0x00から0xffまで自由に送信できる
+	// DataPtr のデータはテキストではないこともあるので考慮が必要
+	wchar_t *strW = NULL;
+	BOOL binary_data = IsBinaryData(DataPtr, DataSize);
+	if (binary_data == FALSE) {
+		strW = ToWcharU8(DataPtr);
+		if (strW == NULL) {
+			// UTF-16LEへ変換できないなら、(多分)バイナリではなくテキスト
+			binary_data = TRUE;
+		}
+		else {
+			// UTF-16 -> UTF-8 に変換、再度比較
+			char *strU8 = ToU8W(strW);
+			if (strU8 == NULL) {
+				binary_data = TRUE;
+			}
+			else {
+				if (strcmp(strU8, DataPtr) != 0) {
+					// 異なっていたらバイナリと判定
+					binary_data = TRUE;
+				}
+				free(strU8);
+			}
+		}
+	}
+
+	if (binary_data) {
+		uint8_t *p = (uint8_t *)malloc(DataSize);
+		memcpy(p, DataPtr, DataSize);
+		SendMem *sm = SendMemBinary(p, DataSize - 1);
+		assert(sm != NULL);
+		if (sm != NULL) {
+			SendMemInitEcho(sm, FALSE);
+			SendMemInitDelay(sm, SENDMEM_DELAYTYPE_NO_DELAY, 0, 0);
+			SendMemStart(sm);
+		}
+	} else {
+		SendMem *sm = SendMemTextW(strW, 0);
+		assert(sm != NULL);
+		if (sm != NULL) {
+			SendMemInitEcho(sm, FALSE);
+			SendMemInitDelay(sm, SENDMEM_DELAYTYPE_PER_LINE, 10, 0);
+			SendMemStart(sm);
+		}
+	}
+}
+
+static void SendStringU8(const char *strU8)
+{
+	wchar_t *strW = ToWcharU8(strU8);
+	if (strW == NULL) {
+		return;
+	}
+	SendMem *sm = SendMemTextW(strW, 0);
+	assert(sm != NULL);
+	if (sm != NULL) {
+		SendMemInitEcho(sm, FALSE);
+		SendMemInitDelay(sm, SENDMEM_DELAYTYPE_PER_LINE, 10, 0);
+		SendMemStart(sm);
+	}
+}
+
+static void SendBinary(const void *data_ptr, DWORD data_size)
+{
+	uint8_t *p = (uint8_t *)malloc(data_size);
+	if (p == NULL) {
+		return;
+	}
+	memcpy(p, data_ptr, data_size);
+	SendMem *sm = SendMemBinary(p, data_size - 1);
+	assert(sm != NULL);
+	if (sm != NULL) {
+		SendMemInitEcho(sm, FALSE);
+		SendMemInitDelay(sm, SENDMEM_DELAYTYPE_NO_DELAY, 0, 0);
+		SendMemStart(sm);
+	}
+	// free(p); 送信完了後に自動で free() される
+}
+
 static HDDEDATA AcceptPoke(HSZ ItemHSz, UINT ClipFmt,
 						   HDDEDATA Data)
 {
@@ -408,41 +470,8 @@ static HDDEDATA AcceptPoke(HSZ ItemHSz, UINT ClipFmt,
 	result = (HDDEDATA)DDE_FNOTPROCESSED;
 	DataPtr = DdeAccessData(Data,&DataSize);
 	if (DataPtr != NULL) {
-		// マクロコマンド "send" で送信すると、0x00から0xffまで自由に送信できる
-		// DataPtr のデータはテキストではないこともあるので考慮が必要
-		wchar_t *strW = NULL;
-		BOOL binary_data = IsBinaryData(DataPtr, DataSize);
-		if (binary_data == FALSE) {
-			strW = ToWcharU8(DataPtr);
-			if (strW == NULL) {
-				// UTF-16LEへ変換できないなら、(多分)バイナリではなくテキスト
-				binary_data = TRUE;
-			}
-		}
-
-		if (binary_data) {
-			size_t len;
-			uint8_t *p = DecodeEscape(DataPtr, DataSize, &len);
-			SendMem *sm = SendMemBinary(p, len - 1);
-			assert(sm != NULL);
-			if (sm != NULL) {
-				SendMemInitEcho(sm, FALSE);
-				SendMemInitDelay(sm, SENDMEM_DELAYTYPE_NO_DELAY, 0, 0);
-				SendMemStart(sm);
-				result = (HDDEDATA)DDE_FACK;
-			}
-			// free(p); 送信完了後に自動で free() される
-		} else {
-			SendMem *sm = SendMemTextW(strW, 0);
-			assert(sm != NULL);
-			if (sm != NULL) {
-				SendMemInitEcho(sm, FALSE);
-				SendMemInitDelay(sm, SENDMEM_DELAYTYPE_PER_LINE, 10, 0);
-				SendMemStart(sm);
-				result = (HDDEDATA)DDE_FACK;
-			}
-			// free(strW);
-		}
+		SendData(DataPtr, DataSize);
+		result = (HDDEDATA)DDE_FACK;
 	}
 	DdeUnaccessData(Data);
 	return result;
@@ -474,18 +503,39 @@ static void SendCallback(void *callback_data)
 	EndDdeCmnd(0);
 }
 
+// 有効時 DdeAccessData() を使って受信データにアクセスする
+// 無効時 DdeGetData() を使って受信データにアクセスする(従来と同じ)
+//		DdeGetData()の場合、データ長上限(MaxStrLen)が存在する
+#define	USE_ACCESSDATA	1
+
 static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 {
+#if USE_ACCESSDATA
+	char *Command;
+#else
 	char Command[MaxStrLen + 1];
+#endif
 	int i;
 	BOOL r;
-
-	memset(Command, 0, sizeof(Command));
+	DWORD len;
+	HDDEDATA result = (HDDEDATA)DDE_FACK;
 
 	if ((ConvH==0) ||
-		(DdeCmpStringHandles(TopicHSz, Topic) != 0) ||
-		(DdeGetData(Data,Command,sizeof(Command),0) == 0))
+		(DdeCmpStringHandles(TopicHSz, Topic) != 0))
 		return DDE_FNOTPROCESSED;
+
+#if USE_ACCESSDATA
+	Command = DdeAccessData(Data, &len);
+	if (Command == NULL || len == 0) {
+		return DDE_FNOTPROCESSED;
+	}
+#else
+	memset(Command, 0, sizeof(Command));
+	len = DdeGetData(Data,Command,sizeof(Command),0);
+	if (len == 0) {
+		return DDE_FNOTPROCESSED;
+	}
+#endif
 
 	switch (Command[0]) {
 	case CmdSetHWnd:
@@ -523,7 +573,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	case CmdBPlusSend: {
 		wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
@@ -533,7 +583,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdChangeDir:
@@ -619,7 +669,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else {
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		}
 		break;
 	case CmdKmtRecv:
@@ -627,7 +677,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	case CmdKmtGet: {
 		wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
@@ -637,7 +687,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdKmtSend: {
@@ -648,7 +698,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdLoadKeyMap: {
@@ -686,7 +736,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		break;
 	case CmdLogOpen:
 		if (FLogIsOpend()) {
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		}
 		else {
 			wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
@@ -714,7 +764,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	case CmdQVSend: {
 		wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
@@ -724,7 +774,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdRestoreSetup: {
@@ -752,7 +802,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdSendKCode: {
@@ -811,7 +861,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdXmodemSend: {
@@ -822,7 +872,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdZmodemRecv:
@@ -830,7 +880,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	case CmdZmodemSend: {
 		wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
@@ -840,7 +890,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 	case CmdYmodemRecv:
@@ -849,7 +899,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	case CmdYmodemSend: {
 		wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
@@ -858,7 +908,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			DdeCmnd = TRUE;
 		}
 		else
-			return DDE_FNOTPROCESSED;
+			result = DDE_FNOTPROCESSED;
 		break;
 	}
 		// add 'callmenu' (2007.11.18 maya)
@@ -887,7 +937,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			if (r == FALSE) {
 				const char *msg = "ttxssh.dll not support scp";
 				MessageBox(NULL, msg, "Tera Term: scprecv command error", MB_OK | MB_ICONERROR);
-				return DDE_FNOTPROCESSED;
+				result = DDE_FNOTPROCESSED;
 			}
 		}
 		break;
@@ -902,7 +952,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			if (r == FALSE) {
 				const char *msg = "ttxssh.dll not support scp";
 				MessageBox(NULL, msg, "Tera Term: scpsend command error", MB_OK | MB_ICONERROR);
-				return DDE_FNOTPROCESSED;
+				result = DDE_FNOTPROCESSED;
 			}
 		}
 		break;
@@ -911,13 +961,12 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		{
 		int val;
 
-		//OutputDebugPrintf("CmdSetBaud entered\n");
-
-		if (!cv.Open || cv.PortType != IdSerial)
-			return DDE_FNOTPROCESSED;
+		if (!cv.Open || cv.PortType != IdSerial) {
+			result = DDE_FNOTPROCESSED;
+			break;
+		}
 
 		val = atoi(ParamFileName);
-		//OutputDebugPrintf("CmdSetBaud: %d (%d)\n", val, ts.Baud);
 		if (val > 0) {
 			ts.Baud = val;
 			CommResetSerial(&ts,&cv,FALSE);   // reset serial port
@@ -930,8 +979,10 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		{
 		int val;
 
-		if (!cv.Open || cv.PortType != IdSerial)
-			return DDE_FNOTPROCESSED;
+		if (!cv.Open || cv.PortType != IdSerial) {
+			result = DDE_FNOTPROCESSED;
+			break;
+		}
 
 		val = atoi(ParamFileName);
 		switch(val) {
@@ -949,8 +1000,10 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		{
 		int val, ret;
 
-		if (!cv.Open || cv.PortType != IdSerial || ts.Flow != IdFlowNone)
-			return DDE_FNOTPROCESSED;
+		if (!cv.Open || cv.PortType != IdSerial || ts.Flow != IdFlowNone) {
+			result = DDE_FNOTPROCESSED;
+			break;
+		}
 
 		val = atoi(ParamFileName);
 		if (val == 0) {
@@ -966,8 +1019,10 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		{
 		int val, ret;
 
-		if (!cv.Open || cv.PortType != IdSerial || ts.Flow != IdFlowNone)
-			return DDE_FNOTPROCESSED;
+		if (!cv.Open || cv.PortType != IdSerial || ts.Flow != IdFlowNone) {
+			result = DDE_FNOTPROCESSED;
+			break;
+		}
 
 		val = atoi(ParamFileName);
 		if (val == 0) {
@@ -983,11 +1038,15 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		{
 		DWORD val, n;
 
-		if (!cv.Open || cv.PortType != IdSerial)
-			return DDE_FNOTPROCESSED;
+		if (!cv.Open || cv.PortType != IdSerial) {
+			result = DDE_FNOTPROCESSED;
+			break;
+		}
 
-		if (GetCommModemStatus(cv.ComID, &val) == 0) // error
-			return DDE_FNOTPROCESSED;
+		if (GetCommModemStatus(cv.ComID, &val) == 0) { // error
+			result = DDE_FNOTPROCESSED;
+			break;
+		}
 		//val = MS_CTS_ON | MS_DSR_ON | MS_RING_ON | MS_RLSD_ON;
 		n = 0;
 		if (val & MS_CTS_ON)
@@ -1062,10 +1121,48 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		FLogInfo(ParamFileName, sizeof(ParamFileName) - 1);
 		break;
 
-	default:
-		return DDE_FNOTPROCESSED;
+	case CmdSendUTF8String:
+	case CmdSendBinary:
+	case CmdSendCompatString: {
+		const char command_byte = Command[0];
+		const uint8_t *lptr = &Command[1];
+		size_t data_len;
+		uint8_t *data_ptr = DecodeDDEBinary(lptr, len - 1, &data_len);
+		uint32_t slen =
+			(data_ptr[0] << (8*3)) +
+			(data_ptr[1] << (8*2)) +
+			(data_ptr[2] << 8) +
+			data_ptr[3];
+		if (slen <= len - 1 - 4) {
+			char *sptr = &data_ptr[4];
+			switch(command_byte) {
+			case CmdSendUTF8String:
+				SendStringU8(sptr);
+				break;
+			case CmdSendBinary:
+				SendBinary(sptr, slen);
+				break;
+			case CmdSendCompatString:
+				SendData(sptr, slen);
+				break;
+			default:
+				assert(FALSE);
+				SendStringU8(sptr);
+				break;
+			}
+		}
+		free(data_ptr);
+		break;
 	}
-	return (HDDEDATA)DDE_FACK;
+
+	default:
+		result = DDE_FNOTPROCESSED;
+		break;
+	}
+#if USE_ACCESSDATA
+	DdeUnaccessData(Data);
+#endif
+	return result;
 }
 
 static HDDEDATA CALLBACK DdeCallbackProc(UINT CallType, UINT Fmt, HCONV Conv,

--- a/teraterm/ttpmacro/ttmparse.cpp
+++ b/teraterm/ttpmacro/ttmparse.cpp
@@ -361,6 +361,8 @@ BOOL CheckReservedWord(PCHAR Str, LPWORD WordId)
 		else if (_stricmp(Str,"sendlnbroadcast")==0) *WordId = RsvSendlnBroadcast;
 		else if (_stricmp(Str,"sendlnmulticast")==0) *WordId = RsvSendlnMulticast;
 		else if (_stricmp(Str,"sendmulticast")==0) *WordId = RsvSendMulticast;
+		else if (_stricmp(Str,"sendtext")==0) *WordId = RsvSendText;
+		else if (_stricmp(Str,"sendbinary")==0) *WordId = RsvSendBinary;
 		else if (_stricmp(Str,"setfileattr")==0) *WordId = RsvSetFileAttr;
 		else if (_stricmp(Str,"setmulticastname")==0) *WordId = RsvSetMulticastName;
 		else if (_stricmp(Str,"sendfile")==0) *WordId = RsvSendFile;

--- a/teraterm/ttpmacro/ttmparse.h
+++ b/teraterm/ttpmacro/ttmparse.h
@@ -281,6 +281,8 @@
 #if defined(OUTPUTDEBUGSTRING_ENABLE)
 #define RsvOutputDebugString	216
 #endif
+#define RsvSendText     217
+#define RsvSendBinary   218
 
 #define RsvOperator     1000
 #define RsvBNot         1001


### PR DESCRIPTION
- 'send $ff $ff $ff' と送信すると 0x3F 0x3F 0x3F("???") が出力される
  - 内部文字コードUTF-16に変換する時、L"???" (変換できない文字3キャラクタ) と変換されるため
  - send コマンドで送信したデータがテキストデータなのかバイナリデータなのか判定を誤っていた
- sendマクロコマンドで送信したデータの判定方法を変更
  - 従来の方法(#189)に加えて - コントロールコード(改行コード以外の0x20未満のデータ)が入っているか?
  - UTF-8 を UTF-16 へ変換、再度UTF-8 へ変換して比較、異なっている場合はバイナリと判定
- sendtext, sendbinary マクロコマンドを追加
  - 送信データの自動判定を行わずに送信できる
- XTYP_EXECUTE を使って文字/バイナリを送信するようにした
  - 通信データ上限をなくした
  - XTYP_POKE は使用しなくなった