### PR TITLE
ShellExecuteW() の使い方を見直した #232

### DIFF
--- a/teraterm/teraterm/setupdirdlg.cpp
+++ b/teraterm/teraterm/setupdirdlg.cpp
@@ -135,6 +135,16 @@ error:
 	return (ret);
 }
 
+static wchar_t *GetExplorerFullPath(void)
+{
+	wchar_t *windows_dir;
+	_SHGetKnownFolderPath(FOLDERID_Windows, 0, NULL, &windows_dir);
+	wchar_t *explorer;
+	aswprintf(&explorer, L"%s\\explorer.exe", windows_dir);
+	free(windows_dir);
+	return explorer;
+}
+
 //
 // 指定したアプリケーションでファイルを開く。
 //
@@ -187,7 +197,6 @@ static BOOL openFileWithApplication(const wchar_t *filename,
 static BOOL openDirectoryWithExplorer(const wchar_t *file, const wchar_t *UILanguageFile)
 {
 	BOOL ret;
-
 	DWORD attr = GetFileAttributesW(file);
 	if (attr == INVALID_FILE_ATTRIBUTES) {
 		// ファイルが存在しない, ディレクトリをオープンする
@@ -195,7 +204,7 @@ static BOOL openDirectoryWithExplorer(const wchar_t *file, const wchar_t *UILang
 		attr = GetFileAttributesW(dir);
 		if ((attr != INVALID_FILE_ATTRIBUTES) && (attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
 			// フォルダを開く
-			INT_PTR h = (INT_PTR)ShellExecuteW(NULL, L"open", L"explorer.exe", dir, NULL, SW_NORMAL);
+			INT_PTR h = (INT_PTR)ShellExecuteW(NULL, L"explore", dir, NULL, NULL, SW_NORMAL);
 			ret = h > 32 ? TRUE : FALSE;
 		}
 		else {
@@ -213,14 +222,16 @@ static BOOL openDirectoryWithExplorer(const wchar_t *file, const wchar_t *UILang
 		free(dir);
 	} else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
 		// 指定されたのがフォルダだった、フォルダを開く
-		INT_PTR h = (INT_PTR)ShellExecuteW(NULL, L"open", L"explorer.exe", file, NULL, SW_NORMAL);
+		INT_PTR h = (INT_PTR)ShellExecuteW(NULL, L"explore", file, NULL, NULL, SW_NORMAL);
 		ret = h > 32 ? TRUE : FALSE;
 	} else {
 		// フォルダを開く + ファイル選択
+		wchar_t *explorer = GetExplorerFullPath();
 		wchar_t *param;
 		aswprintf(&param, L"/select,%s", file);
-		INT_PTR h = (INT_PTR)ShellExecuteW(NULL, L"open", L"explorer.exe", param, NULL, SW_NORMAL);
+		INT_PTR h = (INT_PTR)ShellExecuteW(NULL, L"open", explorer, param, NULL, SW_NORMAL);
 		free(param);
+		free(explorer);
 		ret = h > 32 ? TRUE : FALSE;
 	}
 	return ret;


### PR DESCRIPTION
- 単純にフォルダを開くとき, ShellExecuteW() の "explore" + フォルダ で開くようにした
- ShellExecuteW() で explorer.exe を使用するときはフルパスで指定するよう修正