### PR TITLE
新しい接続ダイアログで常にcomポートリストの一番最初が選択されていたので修正 #256

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -103,6 +103,7 @@
       <li>MACRO: Fixed path of <a href="../macro/command/basename.html">basename</a> and <a href="../macro/command/dirname.html">dirname</a> macro commands were not Unicode-compatible.</li>
       <li>MACRO: Fixed <a href="../macro/command/clipb2var.html">clipb2var</a> is not working.</li>
       <li>MACRO: Fixed ttpmacro.exe crashes when referencing unsetted string array element.</li>
+      <li>Fixed doesn't remember the COM port it used on new connection dialog</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -103,6 +103,7 @@
       <li>MACRO: <a href="../macro/command/basename.html">basename</a>, <a href="../macro/command/dirname.html">dirname</a>マクロコマンドのパスがUnicodeに対応していなかったので修正した。</li>
       <li>MACRO: <a href="../macro/command/clipb2var.html">clipb2var</a>が動作しなかったので修正した。</li>
       <li>MACRO: 文字列配列の未設定要素を参照すると ttpmacro.exe がクラッシュするので修正した。</li>
+      <li>新しい接続ダイアログで、直前に使用したCOMポートを選択しなかったので修正した。</li>
     </ul>
   </li>
 

--- a/teraterm/ttpdlg/hostdlg.c
+++ b/teraterm/ttpdlg/hostdlg.c
@@ -81,6 +81,8 @@ static INT_PTR CALLBACK HostDlg(HWND Dialog, UINT Message, WPARAM wParam, LPARAM
 		case WM_INITDIALOG: {
 			WORD i;
 			int j;
+			int com_index;
+
 			GetHNRec = (PGetHNRec)lParam;
 			dlg_data = (TTXHostDlgData *)calloc(1, sizeof(*dlg_data));
 			SetWindowLongPtr(Dialog, DWLP_USER, (LPARAM)dlg_data);
@@ -97,11 +99,11 @@ static INT_PTR CALLBACK HostDlg(HWND Dialog, UINT Message, WPARAM wParam, LPARAM
 				GetHNRec->PortType = IdTCPIP;
 			}
 
+			// ホスト (コマンドライン)
 			SetComboBoxHostHistory(Dialog, IDC_HOSTNAME, MAXHOSTLIST, GetHNRec->SetupFNW);
 			ExpandCBWidth(Dialog, IDC_HOSTNAME);
 
-			SendDlgItemMessage(Dialog, IDC_HOSTNAME, EM_LIMITTEXT,
-			                   HostNameMaxLength-1, 0);
+			SendDlgItemMessage(Dialog, IDC_HOSTNAME, EM_LIMITTEXT, HostNameMaxLength-1, 0);
 
 			SendDlgItemMessage(Dialog, IDC_HOSTNAME, CB_SETCURSEL,0,0);
 
@@ -117,6 +119,7 @@ static INT_PTR CALLBACK HostDlg(HWND Dialog, UINT Message, WPARAM wParam, LPARAM
 			SendDlgItemMessage(Dialog, IDC_HOSTTCPPROTOCOL, CB_SETCURSEL,0,0);
 
 			j = 0;
+			com_index = 1;
 			for (i = 0; i < dlg_data->ComPortInfoCount; i++) {
 				ComPortInfo_t *p = dlg_data->ComPortInfoPtr + i;
 				wchar_t *EntNameW;
@@ -126,11 +129,15 @@ static INT_PTR CALLBACK HostDlg(HWND Dialog, UINT Message, WPARAM wParam, LPARAM
 				if (i > GetHNRec->MaxComPort) {
 					continue;
 				}
-				j++;
 
 				// 使用中のポートは表示しない
 				if (CheckCOMFlag(p->port_no) == 1) {
 					continue;
+				}
+
+				j++;
+				if (GetHNRec->ComPort == p->port_no) {
+					com_index = j;
 				}
 
 				if (p->friendly_name == NULL) {
@@ -144,7 +151,8 @@ static INT_PTR CALLBACK HostDlg(HWND Dialog, UINT Message, WPARAM wParam, LPARAM
 				free(EntNameW);
 			}
 			if (j>0) {
-				SendDlgItemMessage(Dialog, IDC_HOSTCOM, CB_SETCURSEL,0,0);
+				// GetHNRec->ComPort を選択する
+				SendDlgItemMessageA(Dialog, IDC_HOSTCOM, CB_SETCURSEL, com_index - 1, 0);
 			}
 			else { /* All com ports are already used */
 				GetHNRec->PortType = IdTCPIP;


### PR DESCRIPTION
- 前回使用した(指定された)comポートを選択した状態でダイアログがオープンするようにした
  - Tera Term 4 と同じ動作となった
- 新しい接続ダイアログオープン時comポートが選択されているとフォーカスがおかしくなっていたので修正