### PR TITLE
項目名の誤りを修正 #244

### DIFF
--- a/doc/en/html/menu/setup-additional-copy-and-paste.html
+++ b/doc/en/html/menu/setup-additional-copy-and-paste.html
@@ -67,7 +67,7 @@
 	A user can delay to send a line data to the remote host when the user pastes multiple lines. The delay time can be specified by this option on the millisecond time scale.
       </dd>
 
-      <dt id="SelectOnActivate">Disabling text selection when the window is activated</dt>
+      <dt id="SelectOnActivate">Enabling text selection when the window is activated by mouse</dt>
       <dd>
 	When an inactive window is activated by clicking the text area with the mouse, the text selection is disabled.
       </dd>


### PR DESCRIPTION
- Disabling text selection when the window is activated
  → Enabling text selection when the window is activated by mouse