### PR TITLE
skip LangAppendFileList when ExeDir is same as HomeDir on General Dlg.

### DIFF
--- a/teraterm/ttpdlg/generaldlg.c
+++ b/teraterm/ttpdlg/generaldlg.c
@@ -270,11 +270,11 @@ BOOL WINAPI _SetupGeneral(HWND WndParent, PTTSet ts)
 	aswprintf(&folder, L"%s\\%s", ts->ExeDirW, get_lang_folder());
 	infos = LangAppendFileList(folder, infos, &infos_size);
 	free(folder);
-#if 1
-	aswprintf(&folder, L"%s\\%s", ts->HomeDirW, get_lang_folder());
-	infos = LangAppendFileList(folder, infos, &infos_size);
-	free(folder);
-#endif
+	if (strcmp(ts->ExeDirW, ts->HomeDirW) != 0) {
+		aswprintf(&folder, L"%s\\%s", ts->HomeDirW, get_lang_folder());
+		infos = LangAppendFileList(folder, infos, &infos_size);
+		free(folder);
+	}
 	LangRead(infos, infos_size);
 
 	DlgData data;


### PR DESCRIPTION
Setup - General で表示される LanguageUI のドロップダウンリストの内容が二倍になってしまう現象の回避案です。