### PR TITLE
get the x button back to work on Tera Term Log dialog

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -49,6 +49,7 @@
   <li>Bug fixes
     <ul>
       <li>Fixed a problem that an error is displayed when a new connection is made after disconnecting during log output in the case of LogAutoStart=on.</li>
+      <li>Get the X button back to work on "Log" dialog box.</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -38,17 +38,18 @@
     <ul>
       <li>Setup-General 設定を Additional settings の <a href="../menu/setup-additional-general.html">General タブ</a>へ統合した。</li>
       <li>Additional settings の "Coding" を、より一般的な "Encoding" に改めた。</li>
-      <li>クリップボードの送信(OSC 52)時、送信文字コードで送信するように変更した<br>
+      <li>クリップボードの送信(OSC 52)時、送信文字コードで送信するように変更した。<br>
         修正前はUTF-8 以外の時、ACPで送信していた。</li>
-      <li>言語モードを削除したため /LA コマンドラインオプションを削除した</li>
+      <li>言語モードを削除したため /LA コマンドラインオプションを削除した。</li>
       <li>TERATERM.INI のバックアップファイルの作成方法を変更した。</li>
-      <li>Unicode の文字情報を Unicode 16.0 に更新した。更新前、Tera Term 5.0 から Unicode 15.1 準拠だった</li>
+      <li>Unicode の文字情報を Unicode 16.0 に更新した。更新前、Tera Term 5.0 から Unicode 15.1 準拠だった。</li>
     </ul>
   </li>
 
   <li>バグ修正
     <ul>
       <li>LogAutoStart=on で AutoWinClose=off の時、ログ出力中に切断して新規接続するとエラーが表示される問題を修正した。</li>
+      <li>"Log" ダイアログボックス(ファイルへ書き込み中)の×ボタンが動作しない問題を修正した。</li>
     </ul>
   </li>
 

--- a/teraterm/teraterm/ftdlg.cpp
+++ b/teraterm/teraterm/ftdlg.cpp
@@ -233,7 +233,7 @@ BOOL CFileTransDlg::OnInitDialog()
 	return TRUE;
 }
 
-BOOL CFileTransDlg::OnCancel( )
+BOOL CFileTransDlg::OnCancel()
 {
 	if (OpId == OpLog) {
 		FLogClose();
@@ -241,6 +241,7 @@ BOOL CFileTransDlg::OnCancel( )
 	else {
 		FileSendEnd();
 	}
+	TTSetIcon(m_hInst, m_hWnd, NULL, 0);
 	return TRUE;
 }
 
@@ -271,8 +272,8 @@ BOOL CFileTransDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 
 BOOL CFileTransDlg::OnClose()
 {
-	TTSetIcon(m_hInst, m_hWnd, NULL, 0);
-	return TRUE;
+	// TTSetIcon(m_hInst, m_hWnd, NULL, 0);
+	return OnCancel();
 }
 
 BOOL CFileTransDlg::PostNcDestroy()

--- a/teraterm/teraterm/ftdlg.cpp
+++ b/teraterm/teraterm/ftdlg.cpp
@@ -272,8 +272,7 @@ BOOL CFileTransDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 
 BOOL CFileTransDlg::OnClose()
 {
-	// TTSetIcon(m_hInst, m_hWnd, NULL, 0);
-	return OnCancel();
+	return FALSE;
 }
 
 BOOL CFileTransDlg::PostNcDestroy()


### PR DESCRIPTION
ESCキー押下時もアイコンを解除するようにした。
×ボタンを押したときにアイコン解除しかしなくなっていたが、ESCキー押下と同じ動き（4.x 相当の動作）に戻した。