### PR TITLE
MACRO: CCtrlWindow::OnDpiChanged()の引数の脱字を修正 #346

### DIFF
--- a/teraterm/ttpmacro/ttmmain.cpp
+++ b/teraterm/ttpmacro/ttmmain.cpp
@@ -700,7 +700,7 @@ LRESULT CCtrlWindow::OnMacroBringup(WPARAM wParam, LPARAM lParam)
 	return 0;
 }
 
-LRESULT CCtrlWindow::OnDpiChanged(WPARAM wp, LPARAM)
+LRESULT CCtrlWindow::OnDpiChanged(WPARAM wp, LPARAM lp)
 {
 	const UINT new_dpi = LOWORD(wp);
 	TTSetIcon(m_hInst, m_hWnd, MAKEINTRESOURCEW(IDI_TTMACRO), new_dpi);


### PR DESCRIPTION
issue #346 のPRになります


teraterm/ttpmacro/ttmmain.cpp CCtrlWindow::OnDpiChanged()の第2引数の脱字の修正
修正前：LRESULT CCtrlWindow::OnDpiChanged(WPARAM wp, LPARAM)
修正後：LRESULT CCtrlWindow::OnDpiChanged(WPARAM wp, LPARAM lp)

- lpは使用していないため実害はありません。
- ユーザへの影響がないため、変更履歴への記載は行いません。