### PR TITLE
com0com の "COM%d" デバイスをオープンできるようにした #365

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -49,6 +49,7 @@
       <li>Changed method of creating backup files for TERATERM.INI.</li>
       <li>Updated Unicode information to Unicode 16.0. Before update, Unicode 15.1 compliant since Tera Term 5.0.</li>
       <li>All available character codes can be specified using command line options.</li>
+      <li>Supports ÅgCOM%dÅh style serial ports, which are not Ports class of com0com (virtual serial port driver).
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -49,6 +49,7 @@
       <li>TERATERM.INI のバックアップファイルの作成方法を変更した。</li>
       <li>Unicode の文字情報を Unicode 16.0 に更新した。更新前、Tera Term 5.0 から Unicode 15.1 準拠だった。</li>
       <li>コマンドラインオプションで使用可能文字コードを全て指定できるようにした。</li>
+      <li>com0com(vietual serial port driver) の Ports class ではない "COM%d" 形式のシリアルポートを選択できるようにした。</li>
     </ul>
   </li>
 

--- a/teraterm/common/compat_win.h
+++ b/teraterm/common/compat_win.h
@@ -38,6 +38,7 @@
 #include <windows.h>
 #include <imagehlp.h>	// for SymGetLineFromAddr()
 #include <shlobj.h>		// for SHGetKnownFolderPath()
+#include <setupapi.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -222,6 +223,37 @@ extern HRESULT (WINAPI *pDwmGetWindowAttribute)(HWND hwnd, DWORD dwAttribute, PV
 // msimg32.dll
 extern BOOL(WINAPI *pTransparentBlt)(HDC hdcDest, int xoriginDest, int yoriginDest, int wDest, int hDest, HDC hdcSrc,
 									 int xoriginSrc, int yoriginSrc, int wSrc, int hSrc, UINT crTransparent);
+
+// advapi32.dll
+extern LSTATUS (WINAPI *pRegQueryValueExW)(
+	HKEY hKey,
+	LPCWSTR lpValueName,
+	LPDWORD lpReserved,
+	LPDWORD lpType,
+	LPBYTE lpData,
+	LPDWORD lpcbData);
+LSTATUS _RegQueryValueExW(
+	HKEY hKey,
+	LPCWSTR lpValueName,
+	LPDWORD lpReserved,
+	LPDWORD lpType,
+	LPBYTE lpData,
+	LPDWORD lpcbData);
+
+// setupapi.dll
+extern BOOL (WINAPI *pSetupDiGetDevicePropertyW)(
+	HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, CONST DEVPROPKEY *PropertyKey,
+	DEVPROPTYPE *PropertyType, PBYTE PropertyBuffer, DWORD PropertyBufferSize,
+	PDWORD RequiredSize, DWORD Flags);
+extern BOOL (WINAPI *pSetupDiGetDeviceRegistryPropertyW)(
+	HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData,
+	DWORD Property, PDWORD PropertyRegDataType,
+	PBYTE PropertyBuffer, DWORD PropertyBufferSize, PDWORD RequiredSize);
+BOOL _SetupDiGetDevicePropertyW(
+	HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData,
+	const DEVPROPKEY *PropertyKey, DEVPROPTYPE *PropertyType,
+	PBYTE PropertyBuffer, DWORD PropertyBufferSize,
+	PDWORD RequiredSize, DWORD Flags);
 
 void WinCompatInit();
 

--- a/teraterm/common/comportinfo.cpp
+++ b/teraterm/common/comportinfo.cpp
@@ -37,6 +37,9 @@
 
 #include "ttlib.h"
 #include "codeconv.h"
+#include "asprintf.h"
+#include "compat_win.h"
+#include "win32helper.h"
 
 #include "comportinfo.h"
 
@@ -87,63 +90,11 @@
 #define INITGUID
 #include <guiddef.h>
 
-typedef BOOL (WINAPI *TSetupDiGetDevicePropertyW)(
-	HDEVINFO DeviceInfoSet,
-	PSP_DEVINFO_DATA DeviceInfoData,
-	const DEVPROPKEY *PropertyKey,
-	DEVPROPTYPE *PropertyType,
-	PBYTE PropertyBuffer,
-	DWORD PropertyBufferSize,
-	PDWORD RequiredSize,
-	DWORD Flags
-	);
-
-typedef BOOL (WINAPI *TSetupDiGetDeviceRegistryPropertyW)(
-	HDEVINFO DeviceInfoSet,
-	PSP_DEVINFO_DATA DeviceInfoData,
-	DWORD Property,
-	PDWORD PropertyRegDataType,
-	PBYTE PropertyBuffer,
-	DWORD PropertyBufferSize,
-	PDWORD RequiredSize
-	);
-
-typedef LONG (WINAPI *TRegQueryValueExW)(
-	HKEY hKey,
-	LPCWSTR lpValueName,
-	LPDWORD lpReserved,
-	LPDWORD lpType,
-	LPBYTE lpData,
-	LPDWORD lpcbData
-	);
-
-static BOOL IsWindows9X()
-{
-	return !IsWindowsNTKernel();
-}
-
-static wchar_t *ToWcharA(const char *strA_ptr, size_t strA_len)
-{
-	size_t strW_len = MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS,
-										  strA_ptr, (int)strA_len,
-										  NULL, 0);
-	wchar_t *strW_ptr = (wchar_t*)malloc(sizeof(wchar_t) * strW_len);
-	MultiByteToWideChar(CP_ACP, MB_ERR_INVALID_CHARS,
-						strA_ptr, (int)strA_len,
-						strW_ptr, (int)strW_len);
-	return strW_ptr;
-}
-
 /**
  *	ポート名を取得
  */
 static BOOL GetComPortName(HDEVINFO hDevInfo, SP_DEVINFO_DATA *DeviceInfoData, wchar_t **str)
 {
-	TRegQueryValueExW pRegQueryValueExW =
-		(TRegQueryValueExW)GetProcAddress(
-			GetModuleHandleA("ADVAPI32.dll"), "RegQueryValueExW");
-	DWORD byte_len;
-	DWORD dwType = REG_SZ;
 	HKEY hKey = SetupDiOpenDevRegKey(hDevInfo,
 									 DeviceInfoData,
 									 DICS_FLAG_GLOBAL,
@@ -154,32 +105,11 @@ static BOOL GetComPortName(HDEVINFO hDevInfo, SP_DEVINFO_DATA *DeviceInfoData, w
 		return FALSE;
 	}
 
-	wchar_t* port_name = NULL;
-	long r;
-	if (pRegQueryValueExW != NULL && !IsWindows9X()) {
-		// 9x系ではうまく動作しない
-		r = pRegQueryValueExW(hKey, L"PortName", 0,
-			&dwType, NULL, &byte_len);
-		if (r != ERROR_FILE_NOT_FOUND) {
-			port_name = (wchar_t*)malloc(byte_len);
-			r = pRegQueryValueExW(hKey, L"PortName", 0,
-				&dwType, (LPBYTE)port_name, &byte_len);
-		}
-	} else {
-		r = RegQueryValueExA(hKey, "PortName", 0,
-								&dwType, (LPBYTE)NULL, &byte_len);
-		if (r != ERROR_FILE_NOT_FOUND) {
-			char* port_name_a = (char*)malloc(byte_len);
-			r = RegQueryValueExA(hKey, "PortName", 0,
-				&dwType, (LPBYTE)port_name_a, &byte_len);
-			if (r == ERROR_SUCCESS) {
-				port_name = ToWcharA(port_name_a, byte_len);
-			}
-			free(port_name_a);
-		}
-	}
+	wchar_t *port_name = NULL;
+	long r = hRegQueryValueExW(hKey, L"PortName", 0, NULL, (void **)&port_name, NULL);
+
+	RegCloseKey(hKey);
 	if (r == ERROR_SUCCESS) {
-		RegCloseKey(hKey);
 		*str = port_name;
 		return TRUE;
 	}
@@ -191,194 +121,89 @@ static BOOL GetComPortName(HDEVINFO hDevInfo, SP_DEVINFO_DATA *DeviceInfoData, w
 }
 
 /**
- *	プロパティ取得
- *
- * レジストリの場所(Windows10)
- * HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\Class\{GUID}\0000
- *
+ *	プロパティ文字列作成
  */
-static void GetComProperty(HDEVINFO hDevInfo, SP_DEVINFO_DATA *DeviceInfoData,
-						   wchar_t **friendly_name, wchar_t **prop_str)
+static void CreatePropertyStr(ComPortInfo_t *info)
 {
-	typedef struct {
-		const wchar_t *name;
-		const DEVPROPKEY *PropertyKey;	// for SetupDiGetDeviceProperty() Vista+
-		DWORD Property;					// for SetupDiGetDeviceRegistryProperty() 2000+
-	} list_t;
-	static const list_t list[] = {
-		{ L"Device Friendly Name",
-		  &DEVPKEY_Device_FriendlyName,
-		  SPDRP_FRIENDLYNAME },
-		{ L"Device Instance ID",
-		  &DEVPKEY_Device_InstanceId,
-		  SPDRP_MAXIMUM_PROPERTY },
-		{ L"Device Manufacturer",
-		  &DEVPKEY_Device_Manufacturer,
-		  SPDRP_MFG },
-		{ L"Provider Name",
-		  &DEVPKEY_Device_DriverProvider,
-		  SPDRP_MAXIMUM_PROPERTY },
-		{ L"Driver Date",
-		  &DEVPKEY_Device_DriverDate,
-		  SPDRP_MAXIMUM_PROPERTY },
-		{ L"Driver Version",
-		  &DEVPKEY_Device_DriverVersion,
-		  SPDRP_MAXIMUM_PROPERTY },
-	};
-	TSetupDiGetDevicePropertyW pSetupDiGetDevicePropertyW =
-		(TSetupDiGetDevicePropertyW)GetProcAddress(
-			GetModuleHandleA("Setupapi.dll"),
-			"SetupDiGetDevicePropertyW");
-	TSetupDiGetDeviceRegistryPropertyW pSetupDiGetDeviceRegistryPropertyW =
-		(TSetupDiGetDeviceRegistryPropertyW)GetProcAddress(
-			GetModuleHandleA("Setupapi.dll"),
-			"SetupDiGetDeviceRegistryPropertyW");
+	ComPortInfo_t *p = info;
+	wchar_t *s = NULL;
 
-	*friendly_name = NULL;
-	*prop_str = NULL;
-	wchar_t *p_ptr = NULL;
-	size_t p_len = 0;
-	for (size_t i = 0; i < _countof(list); i++) {
-		const list_t *p = &list[i];
-		BOOL r;
-		wchar_t *prop = NULL;
-
-		if (pSetupDiGetDevicePropertyW != NULL) {
-			// vista以上はすべてここに入る
-			DEVPROPTYPE ulPropertyType;
-			DWORD size;
-			r = pSetupDiGetDevicePropertyW(hDevInfo, DeviceInfoData, p->PropertyKey,
-										   &ulPropertyType, NULL, 0, &size, 0);
-			if (r == FALSE && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
-				BYTE *buf = (BYTE *)malloc(size);
-
-				r = pSetupDiGetDevicePropertyW(hDevInfo, DeviceInfoData, p->PropertyKey,
-											   &ulPropertyType, buf, size, &size, 0);
-				if (ulPropertyType == DEVPROP_TYPE_STRING) {
-					// 文字列なのでそのまま
-					prop = (wchar_t *)buf;
-				} else if (ulPropertyType ==  DEVPROP_TYPE_FILETIME) {
-					// buf = FILETIME 構造体の8バイト
-					SYSTEMTIME stFileTime = {};
-					FileTimeToSystemTime((FILETIME *)buf , &stFileTime);
-					int wbuflen = 64;
-					int buflen = sizeof(wchar_t) * wbuflen;
-					prop = (wchar_t *)malloc(buflen);
-					_snwprintf_s(prop, wbuflen, _TRUNCATE, L"%d-%d-%d",
-								 stFileTime.wMonth, stFileTime.wDay, stFileTime.wYear
-						);
-					free(buf);
-				}
-				else {
-					assert(FALSE);
-				}
-			}
-		} else if (p->PropertyKey == &DEVPKEY_Device_InstanceId) {
-			// InstanceIdはA系で決め打ち
-			DWORD len_a;
-			r = SetupDiGetDeviceInstanceIdA(hDevInfo,
-											DeviceInfoData,
-											NULL, 0,
-											&len_a);
-			if (r == FALSE && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
-				char *str_instance_a = (char *)malloc(len_a);
-				r = SetupDiGetDeviceInstanceIdA(hDevInfo,
-												DeviceInfoData,
-												str_instance_a, len_a,
-												&len_a);
-				if (r != FALSE) {
-					prop = ToWcharA(str_instance_a, len_a);
-				}
-				free(str_instance_a);
-			}
-		} else if (p->Property == SPDRP_MAXIMUM_PROPERTY) {
-			// SetupDiGetDeviceRegistryProperty() 系には存在しないプロパティ
-			r = FALSE;
-		} else if (pSetupDiGetDeviceRegistryPropertyW != NULL && !IsWindows9X()) {
-			// 9x系ではうまく動作しない
-			DWORD dwPropType;
-			DWORD size;
-			r = pSetupDiGetDeviceRegistryPropertyW(hDevInfo,
-												   DeviceInfoData,
-												   p->Property,
-												   &dwPropType,
-												   NULL, 0,
-												   &size);
-			if (r == FALSE) {
-				prop = (wchar_t *)malloc(size);
-				r = pSetupDiGetDeviceRegistryPropertyW(hDevInfo,
-													   DeviceInfoData,
-													   p->Property,
-													   &dwPropType,
-													   (LPBYTE)prop, size,
-													   &size);
-			}
-		} else {
-			DWORD dwPropType;
-			DWORD len_a;
-			r = SetupDiGetDeviceRegistryPropertyA(hDevInfo,
-												  DeviceInfoData,
-												  p->Property,
-												  &dwPropType,
-												  NULL, 0,
-												  &len_a);
-			if (r != FALSE) {
-				char *prop_a = (char *)malloc(len_a);
-				r = SetupDiGetDeviceRegistryPropertyA(hDevInfo,
-													  DeviceInfoData,
-													  p->Property,
-													  &dwPropType,
-													  (PBYTE)prop_a, len_a,
-													  &len_a);
-				if (r != FALSE) {
-					prop = ToWcharA(prop_a, len_a);
-				}
-				free(prop_a);
-			}
-		}
-
-		// prop
-		if (r != FALSE && prop != NULL) {
-			if (i == 0) {
-				// フレンドリーネームのみ
-				*friendly_name = prop;
-			}
-
-			// フレンドリーネームも含めたすべてのプロパティ
-			const size_t name_len = wcslen(p->name);
-			const size_t prop_len = wcslen(prop);
-
-			if (p_len == 0) {
-				p_len = p_len + (name_len + 2 + prop_len + 1);
-				p_ptr = (wchar_t *)malloc(sizeof(wchar_t) * p_len);
-				p_ptr[0] = L'\0';
-			}
-			else {
-				p_len = p_len + (2 + name_len + 2 + prop_len);
-				p_ptr = (wchar_t *)realloc(p_ptr, sizeof(wchar_t) * p_len);
-				wcscat_s(p_ptr, p_len, L"\r\n");
-			}
-			wcscat_s(p_ptr, p_len, p->name);
-			wcscat_s(p_ptr, p_len, L": ");
-			wcscat_s(p_ptr, p_len, prop);
-
-			if (i != 0) {
-				free(prop);
-			}
-		}
+	if (p->friendly_name != NULL) {
+		awcscats(&s, L"Device Friendly Name: ", p->friendly_name, L"\r\n", NULL);
 	}
-
-	*prop_str = p_ptr;
+	if (p->instance_id != NULL) {
+		awcscats(&s, L"Device Instance ID: ", p->instance_id, L"\r\n", NULL);
+	}
+	if (p->manufacturer != NULL) {
+		awcscats(&s, L"Device Manufacturer: ", p->manufacturer, L"\r\n", NULL);
+	}
+	if (p->provider_name != NULL) {
+		awcscats(&s, L"Provider Name: ", p->provider_name, L"\r\n", NULL);
+	}
+	if (p->driverdate != NULL) {
+		awcscats(&s, L"Driver Data: ", p->driverdate, L"\r\n", NULL);
+	}
+	if (p->driverversion != NULL) {
+		awcscats(&s, L"Driver Version: ", p->driverversion, L"\r\n", NULL);
+	};
+	if (p->class_name!= NULL) {
+		awcscats(&s, L"Class: ", p->class_name, L"\r\n", NULL);
+	};
+	if (s == NULL) {
+		awcscats(&s, L"no infomation for ", p->port_name, NULL);
+	}
+	p->property = s;
 }
 
-/* 配列ソート用 */
+
+/**
+ *	情報を取得
+ */
+static void GetComProperty(HDEVINFO hDevInfo, SP_DEVINFO_DATA *DeviceInfoData,
+						   ComPortInfo_t *info)
+{
+	ComPortInfo_t *p = info;
+	hSetupDiGetDevicePropertyW(
+		hDevInfo, DeviceInfoData,
+		&DEVPKEY_Device_FriendlyName, (void **)&p->friendly_name, NULL);
+	hSetupDiGetDevicePropertyW(
+		hDevInfo, DeviceInfoData,
+		&DEVPKEY_Device_InstanceId, (void **)&p->instance_id, NULL);
+	hSetupDiGetDevicePropertyW(
+		hDevInfo, DeviceInfoData,
+		&DEVPKEY_Device_Manufacturer, (void **)&p->manufacturer, NULL);
+	hSetupDiGetDevicePropertyW(
+		hDevInfo, DeviceInfoData,
+		&DEVPKEY_Device_DriverProvider, (void **)&p->provider_name, NULL);
+	hSetupDiGetDevicePropertyW(
+		hDevInfo, DeviceInfoData,
+		&DEVPKEY_Device_DriverDate, (void **)&p->driverdate, NULL);
+	hSetupDiGetDevicePropertyW(
+		hDevInfo, DeviceInfoData,
+		&DEVPKEY_Device_DriverVersion, (void **)&p->driverversion, NULL);
+}
+
+/* COMポート情報ソート */
 static int sort_sub(const void *a_, const void *b_)
 {
 	const ComPortInfo_t *a = (ComPortInfo_t *)a_;
 	const ComPortInfo_t *b = (ComPortInfo_t *)b_;
-	const int a_no = a->port_no;
-	const int b_no = b->port_no;
-	return (a_no == b_no) ? 0 : (a_no > b_no) ? 1 : -1;
+	BOOL a_com = (wcsncmp(a->port_name, L"COM", 3) == 0);
+	BOOL b_com = (wcsncmp(b->port_name, L"COM", 3) == 0);
+	if (a_com && !b_com) {
+		// "COM%d"が後ろ
+		return 1;
+	}
+	if (!a_com && b_com) {
+		// "COM%d"が後ろ
+		return -1;
+	}
+	if (a_com && b_com) {
+		// 両方"COM%d"のときは、数字が大きいほうが後ろ
+		return (a->port_no == b->port_no) ? 0 : (a->port_no > b->port_no) ? 1 : -1;
+	}
+	// アルファベット順並び
+	return wcscmp(a->port_name, b->port_name);
 }
 
 /**
@@ -396,16 +221,17 @@ static ComPortInfo_t *ComPortInfoGetByCreatefile(int *count)
 		if (h != INVALID_HANDLE_VALUE) {
 			CloseHandle(h);
 
-			comport_count++;
-			comport_infos = (ComPortInfo_t *)realloc(comport_infos, sizeof(ComPortInfo_t) * comport_count);
-
-			ComPortInfo_t *p = &comport_infos[comport_count - 1];
+			ComPortInfo_t info = {};
 			wchar_t com_name[12];
 			_snwprintf_s(com_name, _countof(com_name), _TRUNCATE, L"COM%d", i);
-			p->port_name = _wcsdup(com_name);  // COMポート名
-			p->port_no = i;  // COMポート番号
-			p->friendly_name = NULL;
-			p->property = NULL;
+			info.port_name = _wcsdup(com_name);  // COMポート名
+			info.port_no = i;  // COMポート番号
+			CreatePropertyStr(&info);
+
+			comport_count++;
+			comport_infos = (ComPortInfo_t *)realloc(comport_infos, sizeof(ComPortInfo_t) * comport_count);
+			ComPortInfo_t *p = &comport_infos[comport_count - 1];
+			*p = info;
 		}
 	}
 
@@ -413,28 +239,66 @@ static ComPortInfo_t *ComPortInfoGetByCreatefile(int *count)
 	return comport_infos;
 }
 
+/**
+ * COM0COM の class GUID
+ */
+DEFINE_GUID( GUID_DEVCLASS_COM0COM, 0xdf799e12L, 0x3c56, 0x421b, 0xb2, 0x98, 0xb6, 0xd3, 0x64, 0x2b, 0xc8, 0x78 );
+
 static ComPortInfo_t *ComPortInfoGetByGetSetupAPI(int *count)
 {
-	static const GUID *pClassGuids[] = {
-		&GUID_DEVCLASS_PORTS,
-		&GUID_DEVCLASS_MODEM,
-	};
 	int comport_count = 0;
 	ComPortInfo_t *comport_infos = NULL;
 
-	for (int i = 0; i < _countof(pClassGuids); i++) {
-		// List all connected devices
-		HDEVINFO hDevInfo = SetupDiGetClassDevsA(pClassGuids[i], NULL, NULL, DIGCF_PRESENT | DIGCF_PROFILE);
-		if (hDevInfo == INVALID_HANDLE_VALUE) {
-			continue;
-		}
-
-		// Find the ones that are driverless
+	HDEVINFO hDevInfo = SetupDiGetClassDevsA(NULL, NULL, NULL, DIGCF_PRESENT | DIGCF_ALLCLASSES);
+	if (hDevInfo != INVALID_HANDLE_VALUE) {
 		for (DWORD j = 0; ; j++) {
 			SP_DEVINFO_DATA DeviceInfoData = {};
 			DeviceInfoData.cbSize = sizeof (DeviceInfoData);
 			if (!SetupDiEnumDeviceInfo(hDevInfo, j, &DeviceInfoData)) {
 				break;
+			}
+
+			BOOL r;
+			wchar_t *class_str = NULL;
+			do {
+				GUID class_guid;
+
+				// class guid から選択する Windows 7 以前は失敗する
+				r = hSetupDiGetDevicePropertyW(hDevInfo, &DeviceInfoData, &DEVPKEY_Device_ClassGuid, (void **)&class_guid, NULL);
+				if (r == TRUE) {
+					if (memcmp(&class_guid, &GUID_DEVCLASS_PORTS, sizeof(GUID)) == 0) {
+						// シリアルポート(class_str = "Ports"のはず)
+						hSetupDiGetDevicePropertyW(hDevInfo, &DeviceInfoData, &DEVPKEY_Device_Class, (void **)&class_str, NULL);
+						break;
+					}
+					if (memcmp(&class_guid, &GUID_DEVCLASS_MODEM, sizeof(GUID)) == 0) {
+						// モデム(class_str = "Modem"のはず)
+						hSetupDiGetDevicePropertyW(hDevInfo, &DeviceInfoData, &DEVPKEY_Device_Class, (void **)&class_str, NULL);
+						break;
+					}
+					if (memcmp(&class_guid, &GUID_DEVCLASS_COM0COM, sizeof(GUID)) == 0) {
+						// com0com(class_str = "CNCPorts"のはず)
+						hSetupDiGetDevicePropertyW(hDevInfo, &DeviceInfoData, &DEVPKEY_Device_Class, (void **)&class_str, NULL);
+						break;
+					}
+				}
+
+				// classから決める
+				wchar_t *str;
+				r = hSetupDiGetDevicePropertyW(hDevInfo, &DeviceInfoData, &DEVPKEY_Device_Class, (void **)&str, NULL);
+				if (r == TRUE) {
+					// "Ports" が含まれていたら シリアルポートと判定する
+					wchar_t *cmp = wcsstr(str, L"Ports");
+					if (cmp != 0) {
+						class_str = str;
+						break;
+					}
+					free(str);
+				}
+			} while(0);
+			if (class_str == NULL) {
+				// シリアルじゃない、次のデバイスへ
+				continue;
 			}
 
 			// check status
@@ -443,27 +307,41 @@ static ComPortInfo_t *ComPortInfoGetByGetSetupAPI(int *count)
 			ULONG problem = 0;
 			CONFIGRET cr = CM_Get_DevNode_Status(&status, &problem, DeviceInfoData.DevInst, 0);
 			if (cr != CR_SUCCESS) {
+				free(class_str);
 				continue;
 			}
 			if (problem != 0) {
 				// 何らかの問題があった?
+				free(class_str);
 				continue;
 			}
 #endif
 
 			wchar_t *port_name;
 			if (!GetComPortName(hDevInfo, &DeviceInfoData, &port_name)) {
+				free(class_str);
 				continue;
 			}
-			int port_no = 0;
-			if (wcsncmp(port_name, L"COM", 3) == 0) {
-				port_no = _wtoi(port_name+3);
+
+#if 1
+			// "COM%d" ではない場合、検出しない
+			if (wcsncmp(port_name, L"COM", 3) != 0) {
+				free(port_name);
+				free(class_str);
+				continue;
 			}
+#endif
 
 			// 情報取得
-			wchar_t *str_friendly_name = NULL;
-			wchar_t *str_prop = NULL;
-			GetComProperty(hDevInfo, &DeviceInfoData, &str_friendly_name, &str_prop);
+			ComPortInfo_t info = {};
+			info.port_name = port_name;
+			info.class_name = class_str;
+			GetComProperty(hDevInfo, &DeviceInfoData, &info);
+			CreatePropertyStr(&info);
+			int port_no = 0;
+			if (wcsncmp(port_name, L"COM", 3) == 0) {
+				info.port_no = _wtoi(port_name + 3);
+			}
 
 			ComPortInfo_t *p =
 				(ComPortInfo_t *)realloc(comport_infos,
@@ -474,10 +352,7 @@ static ComPortInfo_t *ComPortInfoGetByGetSetupAPI(int *count)
 			comport_infos = p;
 			comport_count++;
 			p = &comport_infos[comport_count-1];
-			p->port_name = port_name;  // COMポート名
-			p->port_no = port_no;  // COMポート番号
-			p->friendly_name = str_friendly_name;  // Device Description
-			p->property = str_prop;  // 全詳細情報
+			*p = info;
 		}
 	}
 
@@ -499,12 +374,13 @@ static ComPortInfo_t *ComPortInfoGetByGetSetupAPI(int *count)
 ComPortInfo_t *ComPortInfoGet(int *count)
 {
 #if defined(_MSC_VER) && _MSC_VER > 1400
-	// VS2005よりあたらしい場合は 9x で起動しないバイナリとなる
+	// Visual Studio 2005よりあたらしいVSでビルドすると
+	// setupapi は使用できるが 9x で起動しないバイナリとなる
 	const bool is_setupapi_supported = true;
 #else
 	// VS2005 or MinGW
 	OSVERSIONINFOA osvi;
-	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+	osvi.dwOSVersionInfoSize = sizeof(osvi);
 	GetVersionExA(&osvi);
 	bool is_setupapi_supported = true;
 	if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS && osvi.dwMajorVersion == 4 && osvi.dwMinorVersion == 0) {
@@ -535,6 +411,12 @@ void ComPortInfoFree(ComPortInfo_t *info, int count)
 		ComPortInfo_t *p = &info[i];
 		free(p->port_name);
 		free(p->friendly_name);
+		free(p->class_name);
+		free(p->instance_id);
+		free(p->manufacturer);
+		free(p->provider_name);
+		free(p->driverdate);
+		free(p->driverversion);
 		free(p->property);
 	}
 	free(info);

--- a/teraterm/common/comportinfo.h
+++ b/teraterm/common/comportinfo.h
@@ -33,10 +33,17 @@ extern "C" {
 #endif
 
 typedef struct {
-	wchar_t *port_name;			// ポート名
-	int port_no;				// 0..128(9x)/255(xp)
+	wchar_t *port_name;			// ポート名 "COM%d" 以外もある
+	int port_no;				// "COM%d" の %d部分, 0の場合は "COM%d" 以外, 1..128(9x)/255(xp) (2^32が上限?)
 	wchar_t *friendly_name;		// 存在しない場合は NULL
-	wchar_t *property;			// 存在しない場合は NULL
+	wchar_t *property;			// 個別の値をまとめた文字列
+	// 個別の値
+	wchar_t *class_name;
+	wchar_t *instance_id;
+	wchar_t *manufacturer;
+	wchar_t *provider_name;
+	wchar_t *driverdate;
+	wchar_t *driverversion;
 } ComPortInfo_t;
 
 ComPortInfo_t *ComPortInfoGet(int *count);

--- a/teraterm/common/win32helper.h
+++ b/teraterm/common/win32helper.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <windows.h>
+#include <setupapi.h>
 
 // VS2005(SDK7.1ˆÈ‰º)‚Ì‚Æ‚«,LSTATUS‚ª‚È‚¢
 #if defined(_MSC_VER) && !defined(__MINGW32__) && _MSC_VER == 1400
@@ -51,6 +52,10 @@ LSTATUS hRegQueryValueExW(HKEY hKey, LPCWSTR lpValueName, LPDWORD lpReserved, LP
 DWORD hGetMenuStringW(HMENU hMenu, UINT uIDItem, UINT flags, wchar_t **text);
 DWORD hDragQueryFileW(HDROP hDrop, UINT iFile, wchar_t **filename);
 DWORD hFormatMessageW(DWORD error, wchar_t **message);
+BOOL hSetupDiGetDevicePropertyW(
+	HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData,
+	const DEVPROPKEY *PropertyKey,
+	void **buf, size_t *buf_size);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- com0com = virtual serial port driver
- シリアルポート、モデムデバイス、に加えて com0com のデバイスもオープンできるようになった
  - ただし "CNCA0" などのデバイス名はオープンできない
- comportinfo.cpp を修正
  - 全デバイスから必要なデバイスを探すようにした
  - 従来OSに対応するためのコードを外部に移動した
    - compat_win.cpp,h
    - win32helper.cpp,h