### PR TITLE
fix typo

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -49,7 +49,7 @@
       <li>Changed method of creating backup files for TERATERM.INI.</li>
       <li>Updated Unicode information to Unicode 16.0. Before update, Unicode 15.1 compliant since Tera Term 5.0.</li>
       <li>All available character codes can be specified using command line options.</li>
-      <li>Supports ÅgCOM%dÅh style serial ports, which are not Ports class of com0com (virtual serial port driver).
+      <li>Supports "COM%d" style serial ports of com0com (virtual serial port driver), which are not Ports class.</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -49,7 +49,7 @@
       <li>TERATERM.INI のバックアップファイルの作成方法を変更した。</li>
       <li>Unicode の文字情報を Unicode 16.0 に更新した。更新前、Tera Term 5.0 から Unicode 15.1 準拠だった。</li>
       <li>コマンドラインオプションで使用可能文字コードを全て指定できるようにした。</li>
-      <li>com0com(vietual serial port driver) の Ports class ではない "COM%d" 形式のシリアルポートを選択できるようにした。</li>
+      <li>com0com(virtual serial port driver) の Ports class ではない "COM%d" 形式のシリアルポートを選択できるようにした。</li>
     </ul>
   </li>
 


### PR DESCRIPTION
通りがかりの修正です。軽微なので issue を立てていません。
- 英語のドキュメントに全角文字が記載されており、charset 指定と合致していない。
- おそらく 日本語文章を DeepL に突っ込んで結果をコピペしたものと推定される。
  - https://github.com/TeraTermProject/teraterm/wiki/Document-rule に反している。
- おそらく 係り受けが期待通りに翻訳されておらず、意味不明になっている。
- タグが閉じていない。
- 綴りが間違っている。