### PR TITLE
TTXChangeFontSize プラグインが動作するよう修正 #366

### DIFF
--- a/teraterm/common/tt_res.h
+++ b/teraterm/common/tt_res.h
@@ -312,7 +312,6 @@
 #define ID_SETUP_TCPIP                  50360
 #define ID_SETUP_GENERAL                50370
 #define ID_SETUP_ADDITIONALSETTINGS     50375
-#define ID_SETUP_ADDITIONALSETTINGS_CODING 50376
 #define ID_SETUP_SAVE                   50380
 #define ID_SETUP_RESTORE                50390
 #define ID_OPEN_SETUP                   50391

--- a/teraterm/teraterm/CMakeLists.txt
+++ b/teraterm/teraterm/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(
   clipboar.h
   commlib.c
   commlib.h
+  externalsetup.cpp
+  externalsetup.h
   filesys.cpp
   filesys.h
   filesys_log.cpp

--- a/teraterm/teraterm/externalsetup.cpp
+++ b/teraterm/teraterm/externalsetup.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2024- TeraTerm Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+
+#include "tttypes.h"
+#include "ttwinman.h"
+#include "buffer.h"
+#include "vtdisp.h"
+#include "vtwin.h"
+#include "vtterm.h"
+#include "commlib.h"
+#include "dlglib.h"
+#include "telnet.h"
+#include "setting.h"
+#include "ttdialog.h"
+
+#include "externalsetup.h"
+
+static struct {
+	BOOL PerProcessCalled;
+	BOOL old_use_unicode_api;
+	char *orgTitle;
+} ExternalSetupData;
+
+/*
+ *	前処理、後処理について
+ *		従来はダイアログ毎に、前処理、後処理が分かれていた
+ *		現在はタブ化され全ての設定が行えるので、全ての前処理、後処理が行われる
+ */
+
+/**
+ *	設定ダイアログを出す前の処理
+ *
+ *	@param	page	処理するタブ
+ *					削除予定
+ */
+static void ExternalSetupPreProcess(CAddSettingPropSheetDlgPage page)
+{
+	ExternalSetupData.PerProcessCalled = TRUE;
+	BOOL all = TRUE;
+	//BOOL all = FALSE;
+	if (page == CAddSettingPropSheetDlgPage::DefaultPage) {
+		all = TRUE;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::CodingPage) {
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::FontPage) {
+		ts.SampleFont = VTFont[0];
+		ExternalSetupData.old_use_unicode_api = UnicodeDebugParam.UseUnicodeApi;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::KeyboardPage) {
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::TcpIpPage) {
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::GeneralPage) {
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::TermPage) {
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::WinPage) {
+		ExternalSetupData.orgTitle = _strdup(ts.Title);
+	}
+}
+
+/**
+ *	設定ダイアログを閉じた後の処理
+ *		ok = TRUE の時は
+ *			設定(tsなど)の値を反映する
+ *		ok = FALSE の時は
+ *			必要であれば後処理を行う
+ *
+ *	@param	page	処理するタブ
+ *					削除予定
+ *	@param	ok		TRUE/FALSE = OKが押された/押されなかった
+ */
+static void ExternalSetupPostProcess(CAddSettingPropSheetDlgPage page, BOOL ok)
+{
+	ExternalSetupData.PerProcessCalled = FALSE;
+
+	//BOOL all = FALSE;
+	BOOL all = TRUE;
+	if (page == CAddSettingPropSheetDlgPage::DefaultPage) {
+		all = TRUE;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::CodingPage) {
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::FontPage) {
+		// Fontタブ
+		if (ExternalSetupData.old_use_unicode_api != UnicodeDebugParam.UseUnicodeApi) {
+			BuffSetDispAPI(UnicodeDebugParam.UseUnicodeApi);
+		}
+		// ANSI表示用のコードページを設定する
+		BuffSetDispCodePage(UnicodeDebugParam.CodePageForANSIDraw);
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::KeyboardPage) {
+		//ResetKeypadMode(TRUE);
+		//ResetIME();
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::TcpIpPage) {
+		;
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::GeneralPage) {
+		if (ok) {
+			ResetCharSet();
+			ResetIME();
+		}
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::TermPage) {
+		if (ok) {
+			pVTWin->SetupTerm();
+		}
+	}
+	if (all || page == CAddSettingPropSheetDlgPage::WinPage) {
+		if (ok) {
+			pVTWin->SetColor();
+
+			// タイトルが変更されていたら、リモートタイトルをクリアする
+			if ((ts.AcceptTitleChangeRequest == IdTitleChangeRequestOverwrite) &&
+				(strcmp(ExternalSetupData.orgTitle, ts.Title) != 0)) {
+				free(cv.TitleRemoteW);
+				cv.TitleRemoteW = NULL;
+			}
+			ChangeWin();
+			ChangeFont();
+
+		}
+		free(ExternalSetupData.orgTitle);
+		ExternalSetupData.orgTitle = NULL;
+	}
+}
+
+/**
+ *	Additional Setting を表示する
+ *
+ *	@param	page	DefaultPage		全てのタブを表示して表示する
+ *					その他			特定のタブを表示する
+ *	@retval	TRUE	"OK"が押された
+ *	@retval	FALSE	"Cancel"が押された
+ *
+ *	関数をコールする順(VTWinからの場合)
+ *	- ExternalSetupPreProcess()
+ *	- OpenExternalSetupTab()
+ *	- ExternalSetupPostProcess()
+ */
+BOOL OpenExternalSetupTab(HWND hWndParent, CAddSettingPropSheetDlgPage page)
+{
+	SetDialogFont(ts.DialogFontNameW, ts.DialogFontPoint, ts.DialogFontCharSet,
+				  ts.UILanguageFileW, "Tera Term", "DLG_TAHOMA_FONT");
+
+	// TEKWin特別処理
+	if (AddsettingCheckWin(hWndParent) == ADDSETTING_WIN_TEK) {
+		if (page == CAddSettingPropSheetDlgPage::WinPage) {
+			// Window Setup
+			CAddSettingPropSheetDlg CAddSetting(hInst, hWndParent);
+			INT_PTR ret = CAddSetting.DoModal();
+			return (ret == IDOK) ? TRUE : FALSE;
+		}
+		assert(FALSE);
+	}
+
+	// VTWin
+
+	// PreProcesが呼ばれているかチェック
+	assert(ExternalSetupData.PerProcessCalled == TRUE);
+
+	int one_page = DefaultPage;
+	CAddSettingPropSheetDlg CAddSetting(hInst, hWndParent);
+	if (one_page == CAddSettingPropSheetDlgPage::DefaultPage) {
+		CAddSetting.SetTreeViewMode(ts.ExperimentalTreePropertySheetEnable);
+	}
+	CAddSetting.SetStartPage((CAddSettingPropSheetDlg::Page)page);
+	INT_PTR ret = CAddSetting.DoModal();
+	return (ret == IDOK) ? TRUE : FALSE;
+}
+
+/*
+ *	ここ以降は vtwin.cpp から UI操作/プラグインからコールされる
+ *		OpenExternalSetup() 以外はフックされていてダイアログが開かない場合がある
+ *		ダイアログが開く場合は OpenExternalSetupTab() がコールされる
+ */
+void OpenExternalSetup(HWND hWndParent)
+{
+	ExternalSetupPreProcess(CAddSettingPropSheetDlgPage::DefaultPage);
+	BOOL r = OpenExternalSetupTab(hWndParent, CAddSettingPropSheetDlgPage::DefaultPage);
+	ExternalSetupPostProcess(CAddSettingPropSheetDlgPage::DefaultPage, r);
+}
+
+/**
+ *
+ *	プラグインからの呼び出し
+ *		SendMessage(HWin, WM_COMMAND, MAKELONG(ID_SETUP_TERMINAL, 0), 0);
+ */
+void OpenSetupTerminal()
+{
+	if (! LoadTTDLG()) {
+		return;
+	}
+	ExternalSetupPreProcess(CAddSettingPropSheetDlgPage::TermPage);
+	BOOL r = (*SetupTerminal)(HVTWin, &ts);
+	ExternalSetupPostProcess(CAddSettingPropSheetDlgPage::TermPage, r);
+}
+
+/**
+ *
+ *	プラグインからの呼び出し
+ *		SendMessage(HWin, WM_COMMAND, MAKELONG(ID_SETUP_WINDOW, 0), 0);
+ */
+void OpenSetupWin()
+{
+	if (! LoadTTDLG()) {
+		return;
+	}
+	ExternalSetupPreProcess(CAddSettingPropSheetDlgPage::WinPage);
+	BOOL r = (*SetupWin)(HVTWin, &ts);
+	ExternalSetupPostProcess(CAddSettingPropSheetDlgPage::WinPage, r);
+}
+
+void OpenSetupFont()
+{
+	if (! LoadTTDLG()) {
+		return;
+	}
+	ExternalSetupPreProcess(CAddSettingPropSheetDlgPage::FontPage);
+	BOOL r = (*ChooseFontDlg)(HVTWin, NULL, &ts);
+	ExternalSetupPostProcess(CAddSettingPropSheetDlgPage::FontPage, r);
+}
+
+void OpenSetupKeyboard()
+{
+	if (! LoadTTDLG()) {
+		return;
+	}
+	ExternalSetupPreProcess(CAddSettingPropSheetDlgPage::KeyboardPage);
+	BOOL r = (*SetupKeyboard)(HVTWin, &ts);
+	ExternalSetupPostProcess(CAddSettingPropSheetDlgPage::KeyboardPage, r);
+}
+
+void OpenSetupTCPIP()
+{
+	if (! LoadTTDLG()) {
+		return;
+	}
+	ExternalSetupPreProcess(CAddSettingPropSheetDlgPage::TcpIpPage);
+	BOOL r = (*SetupTCPIP)(HVTWin, &ts);
+	ExternalSetupPostProcess(CAddSettingPropSheetDlgPage::TcpIpPage, r);
+}
+
+void OpenSetupGeneral()
+{
+	if (! LoadTTDLG()) {
+		return;
+	}
+	ExternalSetupPreProcess(CAddSettingPropSheetDlgPage::GeneralPage);
+	BOOL r = (*SetupGeneral)(HVTWin,&ts);
+	ExternalSetupPostProcess(CAddSettingPropSheetDlgPage::GeneralPage, r);
+}

--- a/teraterm/teraterm/externalsetup.h
+++ b/teraterm/teraterm/externalsetup.h
@@ -26,17 +26,29 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* tcpip dialog */
+#pragma once
 
 #include <windows.h>
 
-#include "tttypes.h"
-#include "externalsetup.h"
+#include "addsetting.h"
 
-#include "ttdlg.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-BOOL WINAPI _SetupTCPIP(HWND WndParent, PTTSet ts)
-{
-	(void)ts;
-	return OpenExternalSetupTab(WndParent, TcpIpPage);
+// “à•”—p
+BOOL OpenExternalSetupTab(HWND hWndParent, CAddSettingPropSheetDlgPage page);
+
+// vtwin‚©‚çŽg—p
+void OpenExternalSetup(HWND hWndParent);
+void OpenSetupTerminal();
+void OpenSetupWin();
+void OpenSetupFont();
+void OpenSetupKeyboard();
+void OpenSetupSerialPort();
+void OpenSetupTCPIP();
+void OpenSetupGeneral();
+
+#ifdef __cplusplus
 }
+#endif

--- a/teraterm/teraterm/font_pp.cpp
+++ b/teraterm/teraterm/font_pp.cpp
@@ -39,7 +39,6 @@
 #include "dlglib.h"
 #include "setting.h"
 #include "vtdisp.h"		// for DispSetLogFont()
-#include "buffer.h"
 #include "compat_win.h"	// for CF_INACTIVEFONTS
 #include "helpid.h"
 #include "codeconv.h"
@@ -296,8 +295,6 @@ static INT_PTR CALLBACK Proc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 						IsDlgButtonChecked(hWnd, IDC_VTFONT_UNICODE) == BST_CHECKED;
 					UnicodeDebugParam.CodePageForANSIDraw =
 						GetDlgItemInt(hWnd, IDC_VTFONT_CODEPAGE_EDIT, NULL, FALSE);
-					// ANSI表示用のコードページを設定する
-					BuffSetDispCodePage(UnicodeDebugParam.CodePageForANSIDraw);
 					ts->ListHiddenFonts = IsDlgButtonChecked(hWnd, IDC_LIST_HIDDEN_FONTS) == BST_CHECKED;
 
 					strncpy_s(ts->VTFont, _countof(ts->VTFont), dlg_data->VTFont.lfFaceName, _TRUNCATE);

--- a/teraterm/teraterm/teraterm.cpp
+++ b/teraterm/teraterm/teraterm.cpp
@@ -67,7 +67,7 @@
 
 static BOOL AddFontFlag;
 static wchar_t *TSpecialFont;
-static CVTWindow* pVTWin;
+CVTWindow* pVTWin;
 static DWORD HtmlHelpCookie;
 
 static void LoadSpecialFont(void)

--- a/teraterm/teraterm/ttermpro.v16.vcxproj
+++ b/teraterm/teraterm/ttermpro.v16.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="color_sample.cpp" />
     <ClCompile Include="commlib.c" />
     <ClCompile Include="dnddlg.cpp" />
+    <ClCompile Include="externalsetup.cpp" />
     <ClCompile Include="filesys.cpp" />
     <ClCompile Include="filesys_log.cpp" />
     <ClCompile Include="filesys_proto.cpp" />
@@ -252,6 +253,7 @@
     <ClInclude Include="coding_pp.h" />
     <ClInclude Include="coding_pp_res.h" />
     <ClInclude Include="color_sample.h" />
+    <ClInclude Include="externalsetup.h" />
     <ClInclude Include="filesys_log_res.h" />
     <ClInclude Include="font_pp.h" />
     <ClInclude Include="font_pp_res.h" />

--- a/teraterm/teraterm/ttermpro.v16.vcxproj.filters
+++ b/teraterm/teraterm/ttermpro.v16.vcxproj.filters
@@ -294,6 +294,9 @@
     <ClCompile Include="color_sample.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="externalsetup.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\..\cygterm\cygterm.ico">
@@ -634,6 +637,9 @@
       <Filter>dialog</Filter>
     </ClInclude>
     <ClInclude Include="color_sample.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externalsetup.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/teraterm/teraterm/ttermpro.v17.vcxproj
+++ b/teraterm/teraterm/ttermpro.v17.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="color_sample.cpp" />
     <ClCompile Include="commlib.c" />
     <ClCompile Include="dnddlg.cpp" />
+    <ClCompile Include="externalsetup.cpp" />
     <ClCompile Include="filesys.cpp" />
     <ClCompile Include="filesys_log.cpp" />
     <ClCompile Include="filesys_proto.cpp" />
@@ -252,6 +253,7 @@
     <ClInclude Include="coding_pp.h" />
     <ClInclude Include="coding_pp_res.h" />
     <ClInclude Include="color_sample.h" />
+    <ClInclude Include="externalsetup.h" />
     <ClInclude Include="filesys_log_res.h" />
     <ClInclude Include="font_pp.h" />
     <ClInclude Include="font_pp_res.h" />

--- a/teraterm/teraterm/ttermpro.v17.vcxproj.filters
+++ b/teraterm/teraterm/ttermpro.v17.vcxproj.filters
@@ -294,6 +294,9 @@
     <ClCompile Include="color_sample.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="externalsetup.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="..\..\cygterm\cygterm.ico">
@@ -634,6 +637,9 @@
       <Filter>dialog</Filter>
     </ClInclude>
     <ClInclude Include="color_sample.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externalsetup.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/teraterm/teraterm/vtwin.h
+++ b/teraterm/teraterm/vtwin.h
@@ -238,10 +238,11 @@ protected:
 
 private:
 	void CodePopup(int client_x, int client_y);
-	void SetColor();
 public:
-	BOOL OpenExternalSetup(HWND hWndParent, CAddSettingPropSheetDlg::Page page);
+	void SetColor();
 };
+
+extern CVTWindow *pVTWin;
 #endif
 
 #ifdef __cplusplus
@@ -249,7 +250,6 @@ extern "C" {
 #endif
 
 void VtwinSetHelpId(DWORD data);
-BOOL OpenExternalSetupOutside(HWND hWndParent, CAddSettingPropSheetDlgPage page);
 
 #ifdef __cplusplus
 }

--- a/teraterm/ttpdlg/choosefontdlg.c
+++ b/teraterm/ttpdlg/choosefontdlg.c
@@ -41,6 +41,7 @@
 #include "ttwinman.h"	// for hInst
 #include "vtwin.h"
 #include "addsetting.h"
+#include "externalsetup.h"
 
 #include "ttdlg.h"
 
@@ -121,5 +122,5 @@ BOOL WINAPI _ChooseFontDlg(HWND WndParent, LPLOGFONTA LogFont, const TTTSet *ts)
 		return ChooseFontDlgForTek(WndParent, LogFont, ts);
 	}
 
-	return OpenExternalSetupOutside(WndParent, FontPage);
+	return OpenExternalSetupTab(WndParent, FontPage);
 }

--- a/teraterm/ttpdlg/generaldlg.c
+++ b/teraterm/ttpdlg/generaldlg.c
@@ -28,11 +28,11 @@
 
 /* general dialog */
 #include <windows.h>
-#include "vtwin.h"
+#include "externalsetup.h"
 #include "ttdlg.h"
 
 BOOL WINAPI _SetupGeneral(HWND WndParent, PTTSet ts)
 {
 	(void)ts;
-	return OpenExternalSetupOutside(WndParent, GeneralPage);
+	return OpenExternalSetupTab(WndParent, GeneralPage);
 }

--- a/teraterm/ttpdlg/keyboarddlg.c
+++ b/teraterm/ttpdlg/keyboarddlg.c
@@ -29,12 +29,12 @@
 /* keyboard dialog */
 
 #include <windows.h>
-#include "vtwin.h"
+#include "externalsetup.h"
 
 #include "ttdlg.h"
 
 BOOL WINAPI _SetupKeyboard(HWND WndParent, PTTSet ts)
 {
 	(void)ts;
-	return OpenExternalSetupOutside(WndParent, KeyboardPage);
+	return OpenExternalSetupTab(WndParent, KeyboardPage);
 }

--- a/teraterm/ttpdlg/termdlg.c
+++ b/teraterm/ttpdlg/termdlg.c
@@ -30,12 +30,12 @@
 /* terminal dialog */
 
 #include <windows.h>
-#include "vtwin.h"
+#include "externalsetup.h"
 
 #include "ttdlg.h"
 
 BOOL WINAPI _SetupTerminal(HWND WndParent, PTTSet ts)
 {
 	(void)ts;
-	return OpenExternalSetupOutside(WndParent, TermPage);
+	return OpenExternalSetupTab(WndParent, TermPage);
 }

--- a/teraterm/ttpdlg/ttdlg.c
+++ b/teraterm/ttpdlg/ttdlg.c
@@ -30,12 +30,12 @@
 #include <windows.h>
 
 #include "tttypes.h"
-#include "vtwin.h"
+#include "externalsetup.h"
 
 #include "ttdlg.h"
 
 BOOL WINAPI _ChangeDirectory(HWND WndParent, PTTSet ts)
 {
 	(void)ts;
-	return OpenExternalSetupOutside(WndParent, GeneralPage);
+	return OpenExternalSetupTab(WndParent, GeneralPage);
 }

--- a/teraterm/ttpdlg/windlg.cpp
+++ b/teraterm/ttpdlg/windlg.cpp
@@ -29,12 +29,12 @@
 // WinDlg
 
 #include <windows.h>
-#include "vtwin.h"
+#include "externalsetup.h"
 
 #include "ttdlg.h"
 
 BOOL WINAPI _SetupWin(HWND WndParent, PTTSet ts)
 {
 	(void)ts;
-	return OpenExternalSetupOutside(WndParent, WinPage);
+	return OpenExternalSetupTab(WndParent, WinPage);
 }


### PR DESCRIPTION
- vtwinのフックを含んだダイアログを表示するコードをまとめた
  - externalsetup.cpp,h に移動した
- フォント選択ができなくなっていたので修正
- 未使用ID削除
  - ID_SETUP_ADDITIONALSETTINGS_CODING