### PR TITLE
getenvにより環境変数定義を取得した際に、日本語を含んでいると文字化けする #388

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -64,6 +64,7 @@
       <li>MACRO: Fixed TTL cannot be execute when it is UTF-8 without BOM.</li>
       <li>Fixed to handle U+20000 to U+3FFFF of UTF-8.</li>
       <li>Fixed display characters containing surrogate pair character when "<a href="../menu/setup-additional-font.html#ResizedFont">Drawing resized font to fit cell width</a>"
+      <li>MACRO: Fixed <a href="../macro/command/getenv.html">getenv</a>, <a href="../macro/command/expandenv.html">expandenv</a> and <a href="../macro/command/setenv.html">setenv</a> macro commands were not Unicode-compatible.</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -64,6 +64,7 @@
       <li>MACRO: TTL ファイルが BOM なし UTF-8 の場合、実行できない問題を修正した。</li>
       <li>UTF-8 の U+20000 から U+3FFFF を正しく扱うよう修正した。</li>
       <li>"<a href="../menu/setup-additional-font.html#ResizedFont">Drawing resized font to fit cell width</a>" が on のとき、サロゲートペアの文字が存在したとき正しく表示するよう修正した。</li>
+      <li>MACRO: <a href="../macro/command/getenv.html">getenv</a>, <a href="../macro/command/expandenv.html">expandenv</a>, <a href="../macro/command/setenv.html">setenv</a> マクロコマンド が Unicode に対応していなかったので修正した。</li>
     </ul>
   </li>
 

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -4249,7 +4249,11 @@ static WORD TTLSetEnv(void)
 		Err = ErrSyntax;
 	if (Err!=0) return Err;
 
-	_putenv_s(Str,Str2);
+	wchar_t *varnameW = ToWcharU8(Str);
+	wchar_t *value_stringW = ToWcharU8(Str2);
+	_wputenv_s(varnameW, value_stringW);
+	free(varnameW);
+	free(value_stringW);
 	return Err;
 }
 

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -2369,12 +2369,16 @@ static WORD TTLGetEnv(void)
 		Err = ErrSyntax;
 	if (Err!=0) return Err;
 
-	Str2 = getenv(Str);
-
-	if (Str2!=NULL)
-		SetStrVal(VarId,Str2);
-	else
-		SetStrVal(VarId,"");
+	wchar_t *varnameW = ToWcharU8(Str);
+	const wchar_t *envW = _wgetenv(varnameW);
+	if (envW != NULL) {
+		char *envU8 = ToU8W(envW);
+		SetStrVal(VarId, envU8);
+		free(envU8);
+	} else {
+		SetStrVal(VarId, "");
+	}
+	free(varnameW);
 	return Err;
 }
 

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -1238,7 +1238,7 @@ static WORD TTLExpandEnv(void)
 {
 	WORD Err;
 	TVarId VarId;
-	TStrVal deststr, srcptr;
+	TStrVal srcptr;
 
 	Err = 0;
 	GetStrVar(&VarId, &Err);
@@ -1252,14 +1252,27 @@ static WORD TTLExpandEnv(void)
 			return Err;
 		}
 
-		// ファイルパスに環境変数が含まれているならば、展開する。
-		ExpandEnvironmentStrings(srcptr, deststr, MaxStrLen);
-		SetStrVal(VarId, deststr);
+		// 環境変数が含まれているならば、展開する。
+		wchar_t *srcW = ToWcharU8(srcptr);
+		wchar_t *destW;
+		hExpandEnvironmentStringsW(srcW, &destW);
+		free(srcW);
+		char *destU8 = ToU8W(destW);
+		free(destW);
+		SetStrVal(VarId, destU8);
+		free(destU8);
 	}
 	else { // expandenv strvar
-		// ファイルパスに環境変数が含まれているならば、展開する。
-		ExpandEnvironmentStrings(StrVarPtr(VarId), deststr, MaxStrLen);
-		SetStrVal(VarId, deststr);
+		// 環境変数が含まれているならば、展開する。
+		const char *srcU8 = StrVarPtr(VarId);
+		wchar_t *srcW = ToWcharU8(srcU8);
+		wchar_t *destW;
+		hExpandEnvironmentStringsW(srcW, &destW);
+		free(srcW);
+		char *destU8 = ToU8W(destW);
+		free(destW);
+		SetStrVal(VarId, destU8);
+		free(destU8);
 	}
 
 	return Err;
@@ -2360,7 +2373,6 @@ static WORD TTLGetEnv(void)
 	WORD Err;
 	TVarId VarId;
 	TStrVal Str;
-	PCHAR Str2;
 
 	Err = 0;
 	GetStrVal(Str,&Err);


### PR DESCRIPTION
マクロコマンド getenv, expandenv, setenv が Unicode に対応していなかったので修正した