### PR TITLE
Send file 時 local echo 設定を反映するよう修正 #393

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -73,6 +73,13 @@
       <li>Fixed display characters containing surrogate pair character when "<a href="../menu/setup-additional-font.html#ResizedFont">Drawing resized font to fit cell width</a>"
       <li>MACRO: Fixed <a href="../macro/command/getenv.html">getenv</a>, <a href="../macro/command/expandenv.html">expandenv</a> and <a href="../macro/command/setenv.html">setenv</a> macro commands were not Unicode-compatible.</li>
       <li>Fixed B-plus send is not working</li>
+      <li>Fixed local echo setting was not used:
+        <ul>
+          <li>Send file (<a href="../menu/file-sendfile.html">file - Send file</a>)</li>
+          <li>Send file (<a href="../usage/mouse.html#SendFile">Drop File</a>)</li>
+          <li><a href="../macro/command/sendfile.html">sendfile</a> macro command</li>
+        </ul>
+      </li>
     </ul>
   </li>
 

--- a/doc/en/html/usage/mouse.html
+++ b/doc/en/html/usage/mouse.html
@@ -115,7 +115,7 @@ The first click is the start position and the next Shift+click is the end positi
             </dd>
           </dl>
         </dd>
-        <dt>Send File (Paste content of file)</dt>
+        <dt id="SendFile">Send File (Paste content of file)</dt>
         <dd>
           The file content is sent(pasted) into the terminal.<br>
           When the file is dropped, this menu can be selected with the file. <br>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -73,6 +73,13 @@
       <li>"<a href="../menu/setup-additional-font.html#ResizedFont">Drawing resized font to fit cell width</a>" が on のとき、サロゲートペアの文字が存在したとき正しく表示するよう修正した。</li>
       <li>MACRO: <a href="../macro/command/getenv.html">getenv</a>, <a href="../macro/command/expandenv.html">expandenv</a>, <a href="../macro/command/setenv.html">setenv</a> マクロコマンド が Unicode に対応していなかったので修正した。</li>
       <li>B-Plusの送信ができなくなっていたので修正した。</li>
+      <li>次の時 local echo 設定を反映していなかったので修正した。
+        <ul>
+          <li>ファイル送信 (<a href="../menu/file-sendfile.html">file - Send file</a>)</li>
+          <li>ファイル送信 (<a href="../usage/mouse.html#SendFile">Drop File</a>)</li>
+          <li><a href="../macro/command/sendfile.html">sendfile</a> マクロコマンド</li>
+        </ul>
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/usage/mouse.html
+++ b/doc/ja/html/usage/mouse.html
@@ -117,7 +117,7 @@ VT window
             </dd>
           </dl>
         </dd>
-        <dt>Send File (Paste content of file)</dt>
+        <dt id="SendFile">Send File (Paste content of file)</dt>
         <dd>
           ファイルの内容を端末内に送信(ペースト)します。<br>
           ドロップ内容がファイルだけのとき選択できます。<br>

--- a/teraterm/teraterm/sendmem.cpp
+++ b/teraterm/teraterm/sendmem.cpp
@@ -712,7 +712,7 @@ BOOL SendMemSendFile(const wchar_t *filename, BOOL binary, SendMemDelayType dela
 	return r;
 }
 #else
-SendMem *SendMemSendFileCom(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max)
+SendMem *SendMemSendFileCom(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max, BOOL local_echo)
 {
 	SendMem *sm;
 	if (!binary) {
@@ -743,20 +743,22 @@ SendMem *SendMemSendFileCom(const wchar_t *filename, BOOL binary, SendMemDelayTy
 	SendMemInitDialogCaption(sm, L"send file");			// title
 	SendMemInitDialogFilename(sm, filename);
 	SendMemInitDelay(sm, delay_type, delay_tick, send_max);
+	SendMemInitEcho(sm, local_echo);
+
 	SendMemStart(sm);
 	return sm;
 }
 #endif
 
-BOOL SendMemSendFile(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max)
+BOOL SendMemSendFile(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max, BOOL local_echo)
 {
-	SendMem *sm = SendMemSendFileCom(filename, binary, delay_type, delay_tick, send_max);
+	SendMem *sm = SendMemSendFileCom(filename, binary, delay_type, delay_tick, send_max, local_echo);
 	return (sm != NULL) ? TRUE : FALSE;
 }
 
-BOOL SendMemSendFile2(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max, void (*callback)(void *data), void *callback_data)
+BOOL SendMemSendFile2(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max, BOOL local_echo, void (*callback)(void *data), void *callback_data)
 {
-	SendMem *sm = SendMemSendFileCom(filename, binary, delay_type, delay_tick, send_max);
+	SendMem *sm = SendMemSendFileCom(filename, binary, delay_type, delay_tick, send_max, local_echo);
 	if (sm == NULL) {
 		return FALSE;
 	}

--- a/teraterm/teraterm/sendmem.h
+++ b/teraterm/teraterm/sendmem.h
@@ -59,8 +59,8 @@ void SendMemContinuously(void);
 
 // convenient function
 BOOL SendMemPasteString(wchar_t *str);
-BOOL SendMemSendFile(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max);
-BOOL SendMemSendFile2(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max, void (*callback)(void *data), void *callback_data);
+BOOL SendMemSendFile(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max, BOOL local_echo);
+BOOL SendMemSendFile2(const wchar_t *filename, BOOL binary, SendMemDelayType delay_type, DWORD delay_tick, size_t send_max, BOOL local_echo, void (*callback)(void *data), void *callback_data);
 
 #ifdef __cplusplus
 }

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -796,7 +796,7 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 		BOOL r = FileSendStart(ParamFileNameW, ParamBinaryFlag);
 #else
 		// 5 Ç≈í«â¡ÇµÇΩï˚ñ@Ç≈ëóêM
-		BOOL r = SendMemSendFile2(ParamFileNameW, ParamBinaryFlag, 0, 0, 0, SendCallback, NULL);
+		BOOL r = SendMemSendFile2(ParamFileNameW, ParamBinaryFlag, SENDMEM_DELAYTYPE_NO_DELAY, 0, 0, ts.LocalEcho, SendCallback, NULL);
 #endif
 		free(ParamFileNameW);
 		if (r) {

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -1770,12 +1770,8 @@ LRESULT CVTWindow::OnDropNotify(WPARAM ShowDialog, LPARAM lparam)
 			// cancel
 			break;
 		case DROP_TYPE_SEND_FILE: {
-			if (!data->TransBin) {
-				SendMemSendFile2(FileName, FALSE, SENDMEM_DELAYTYPE_NO_DELAY, 0, 0, DropSendCallback, data);
-			}
-			else {
-				SendMemSendFile2(FileName, TRUE, SENDMEM_DELAYTYPE_NO_DELAY, 0, 0, DropSendCallback, data);
-			}
+			const BOOL binary = data->TransBin ? TRUE : FALSE;
+			SendMemSendFile2(FileName, binary, SENDMEM_DELAYTYPE_NO_DELAY, 0, 0, ts.LocalEcho, DropSendCallback, data);
 			break;
 		}
 		case DROP_TYPE_PASTE_FILENAME:
@@ -3996,7 +3992,7 @@ void CVTWindow::OnFileSend()
 	wchar_t *filename = data.filename;
 	if (!data.method_4) {
 		// new file send
-		SendMemSendFile(filename, data.binary, data.delay_type, data.delay_tick, data.send_size);
+		SendMemSendFile(filename, data.binary, data.delay_type, data.delay_tick, data.send_size, ts.LocalEcho);
 	}
 	else {
 		// file send same as teraterm 4


### PR DESCRIPTION
- "Tera Term 4 と同じ方法で送信"=OFF 時
- Terminal tab - Local echo の設定
- file - send file... はローカルエコー設定を反映するようにした
  - "Tera Term 4 と同じ方法で送信" は反映するようになっていた
- 次のファイル送信も local echo 設定を反映するようにした
  - sendfile マクロコマンド
  - Drag and Drop でのファイルの内容送信