### PR TITLE
ZMODEM send: Disable window if receiver does not set CANFDX flag

### DIFF
--- a/teraterm/ttpfile/zmodem.c
+++ b/teraterm/ttpfile/zmodem.c
@@ -880,6 +880,10 @@ static void ZParseRInit(PFileVarProto fv, PZVar zv)
 	/* file open */
 	zv->FileOpen = file->OpenRead(file, zv->FullName);
 
+	if ((zv->RxHdr[ZF0] & CANFDX) == 0) {
+		zv->WinSize = 0;
+	}
+
 	if (zv->CtlEsc) {
 		if ((zv->RxHdr[ZF0] & ESCCTL) == 0) {
 			zv->ZState = Z_SendInitHdr;
@@ -888,10 +892,6 @@ static void ZParseRInit(PFileVarProto fv, PZVar zv)
 		}
 	} else
 		zv->CtlEsc = (zv->RxHdr[ZF0] & ESCCTL) != 0;
-
-	if ((zv->RxHdr[ZF0] & CANFDX) == 0) {
-		zv->WinSize = 0;
-	}
 
 	Max = (zv->RxHdr[ZP1] << 8) + zv->RxHdr[ZP0];
 	if (Max <= 0)

--- a/teraterm/ttpfile/zmodem.c
+++ b/teraterm/ttpfile/zmodem.c
@@ -889,6 +889,10 @@ static void ZParseRInit(PFileVarProto fv, PZVar zv)
 	} else
 		zv->CtlEsc = (zv->RxHdr[ZF0] & ESCCTL) != 0;
 
+	if ((zv->RxHdr[ZF0] & CANFDX) == 0) {
+		zv->WinSize = 0;
+	}
+
 	Max = (zv->RxHdr[ZP1] << 8) + zv->RxHdr[ZP0];
 	if (Max <= 0)
 		Max = 1024;

--- a/teraterm/ttpfile/zmodem.c
+++ b/teraterm/ttpfile/zmodem.c
@@ -884,6 +884,12 @@ static void ZParseRInit(PFileVarProto fv, PZVar zv)
 		zv->WinSize = 0;
 	}
 
+	Max = (zv->RxHdr[ZP1] << 8) + zv->RxHdr[ZP0];
+	if (Max <= 0)
+		Max = 1024;
+	if (zv->MaxDataLen > Max)
+		zv->MaxDataLen = Max;
+
 	if (zv->CtlEsc) {
 		if ((zv->RxHdr[ZF0] & ESCCTL) == 0) {
 			zv->ZState = Z_SendInitHdr;
@@ -892,12 +898,6 @@ static void ZParseRInit(PFileVarProto fv, PZVar zv)
 		}
 	} else
 		zv->CtlEsc = (zv->RxHdr[ZF0] & ESCCTL) != 0;
-
-	Max = (zv->RxHdr[ZP1] << 8) + zv->RxHdr[ZP0];
-	if (Max <= 0)
-		Max = 1024;
-	if (zv->MaxDataLen > Max)
-		zv->MaxDataLen = Max;
 
 	zv->ZState = Z_SendFileHdr;
 	ZSendFileHdr(zv);


### PR DESCRIPTION
If the receiver does not set CANFDX, then the sender should wait for the receiver to send ZACK for each data subpacket before sending more data.

This allows ZMODEM to be used with a small embedded device that needs ZMODEM to pause while it writes to Flash memory.