### PR TITLE
マクロコマンド setpassword, ispassword を Unicode 対応に修正 #422

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -73,7 +73,7 @@
       <li>MACRO: Fixed TTL cannot be execute when it is UTF-8 without BOM.</li>
       <li>Fixed to handle U+20000 to U+3FFFF of UTF-8.</li>
       <li>Fixed display characters containing surrogate pair character when "<a href="../menu/setup-additional-font.html#ResizedFont">Drawing resized font to fit cell width</a>"
-      <li>MACRO: Fixed <a href="../macro/command/getenv.html">getenv</a>, <a href="../macro/command/expandenv.html">expandenv</a> and <a href="../macro/command/setenv.html">setenv</a> macro commands were not Unicode-compatible.</li>
+      <li>MACRO: Fixed <a href="../macro/command/getenv.html">getenv</a>, <a href="../macro/command/expandenv.html">expandenv</a> and <a href="../macro/command/setenv.html">setenv</a> macro commands were not Unicode compatible.</li>
       <li>Fixed B-plus send is not working</li>
       <li>Fixed local echo setting was not used:
         <ul>
@@ -83,6 +83,7 @@
         </ul>
       </li>
       <li>Fixed "&lt;Edit History... &gt;" is entered in edit box when there is no connection history.
+      <li>MACRO: Fixed <a href="../macro/command/setpassword.html">setpassword</a> and <a href="../macro/command/ispassword.html">ispassword</a> macro commands were not Unicode compatible.</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -83,6 +83,7 @@
         </ul>
       </li>
       <li>接続履歴がないとき、エディットボックスに"&lt;Edit History...&gt;"が入力されていたので修正した。</li>
+      <li>MACRO: <a href="../macro/command/setpassword.html">setpassword</a>, <a href="../macro/command/ispassword.html">ispassword</a> マクロコマンド が Unicode に対応していなかったので修正した。</li>
     </ul>
   </li>
 

--- a/teraterm/ttpmacro/ttl.cpp
+++ b/teraterm/ttpmacro/ttl.cpp
@@ -2611,7 +2611,7 @@ static WORD TTLSetPassword(void)
 	// パスワードを暗号化する。
 	Encrypt(PassStr, Temp);
 
-	if (WritePrivateProfileString("Password", KeyStr, Temp, FileNameStr) != 0)
+	if (WritePrivateProfileStringW(L"Password", wc::fromUtf8(KeyStr), wc::fromUtf8(Temp), wc::fromUtf8(FileNameStr)) != 0)
 		result = 1;  /* success */
 
 	SetResult(result);  // 成功可否を設定する。
@@ -2654,7 +2654,7 @@ static WORD TTLSetPassword2(void)
 static WORD TTLIsPassword(void)
 {
 	TStrVal FileNameStr, KeyStr;
-	char Temp[512];
+	wchar_t Temp[512];
 	WORD Err;
 	int result = 0;
 
@@ -2674,8 +2674,8 @@ static WORD TTLIsPassword(void)
 	GetAbsPath(FileNameStr, sizeof(FileNameStr));
 
 	Temp[0] = 0;
-	GetPrivateProfileString("Password", KeyStr,"",
-	                        Temp, sizeof(Temp), FileNameStr);
+	GetPrivateProfileStringW(L"Password", wc::fromUtf8(KeyStr), L"",
+							 Temp, _countof(Temp), wc::fromUtf8(FileNameStr));
 	if (Temp[0] == 0) { // password not exist
 		result = 0;
 	} else {


### PR DESCRIPTION
- Write(Get)PrivateProfileStringW() API を使用するようにした
  - 修正前は Write(Get)PrivateProfileStringA() API を使用していた