### PR TITLE
XMODEM SEND時、送信方法が途中で切り替わらないようにした #428

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -86,6 +86,7 @@
       <li>Fixed "&lt;Edit History... &gt;" is entered in edit box when there is no connection history.
       <li>Unicode support for jump list display.</li>
       <li>MACRO: Fixed <a href="../macro/command/setpassword.html">setpassword</a> and <a href="../macro/command/ispassword.html">ispassword</a> macro commands were not Unicode compatible.</li>
+      <li>XMODEM Send: Fixed problem switching from XMODEM(CRC) to XMODEM(checksum).</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -86,6 +86,7 @@
       <li>接続履歴がないとき、エディットボックスに"&lt;Edit History...&gt;"が入力されていたので修正した。</li>
       <li>ジャンプリストの表示をUnicodeに対応した。</li>
       <li>MACRO: <a href="../macro/command/setpassword.html">setpassword</a>, <a href="../macro/command/ispassword.html">ispassword</a> マクロコマンド が Unicode に対応していなかったので修正した。</li>
+      <li>XMODEM Send: XMODEM(CRC)からXMODEM(checksum)に切り替わってしまう問題を修正した</li>
     </ul>
   </li>
 

--- a/teraterm/ttpfile/xmodem.c
+++ b/teraterm/ttpfile/xmodem.c
@@ -534,7 +534,7 @@ static BOOL XSendPacket(PFileVarProto fv, PComVar cv)
 				}
 				break;
 			case NAK:
-				if (xv->PktNum == 0 && xv->PktNumOffset == 0) {
+				if ((xv->PktNum == 0) && (xv->PktNumOffset == 0) && (xv->PktNumSent == 0)) {
 					if (!is0x43Received) { //先にCRC要求'C'(0x43)を受け付けていた場合はCRCモードを維持。(CRCで送って受け付けなかった場合はNAKを送ってくるはずなのでCheckSumでの再送に切り替わる)
 						if (xv->XOpt == XoptCRC) {
 							// receiver wants to use checksum.


### PR DESCRIPTION
- XMODEM(CRC)で開始(Cを受信)した後、最初のパケットの応答がNAKの時、 XMODEM(checksum)に切り替わらないようにした
  - 最初のパケットの応答のNAKで、XMODEM(checksum)に切り替わっていた。