### PR TITLE
正しいDPIが取得できない場合でも動作するよう修正 #449

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -67,6 +67,7 @@
         <li>Only settings in this tab.(New connections are made from <a href="../menu/file-new.html">New connection dialog</a>.)</li>
         <li>Select TCP/IP or Serial as <a href="../menu/setup-additional-general.html#Port">new connection default</a> for New connection dialog on General tab. Select default Serial port on Serial tab.</li>
       </ul>
+      <li>Resolved problem that Windows 11 24H2 returns incorrectly monitor information when moving across displays with different DPI, so that window are displayed at correct DPI.</li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -67,6 +67,7 @@
         <li>設定のみ行うようになった。(新しい接続は<a href="../menu/file-new.html">New connection ダイアログ</a>から行う。)</li>
         <li>Additional settings - General タブの<a href="../menu/setup-additional-general.html#Port">新しい接続のデフォルト</a>は TCP/IP 又は Serial を選択、デフォルトのSerial portはこのタブで選択するようにした。</li>
       </ul>
+      <li>DPIが異なるディスプレイをまたいで移動した時、Windows 11(24H2)が誤ったモニタ情報を返す問題を解決して、ウィンドウが正しいDPIで表示するようにした。</li>
     </ul>
   </li>
 

--- a/teraterm/teraterm/externalsetup.cpp
+++ b/teraterm/teraterm/externalsetup.cpp
@@ -156,7 +156,7 @@ static void ExternalSetupPostProcess(CAddSettingPropSheetDlgPage page, BOOL ok)
 				cv.TitleRemoteW = NULL;
 			}
 			ChangeWin();
-			ChangeFont();
+			ChangeFont(0);
 
 		}
 		free(ExternalSetupData.orgTitle);

--- a/teraterm/teraterm/font_pp.cpp
+++ b/teraterm/teraterm/font_pp.cpp
@@ -266,7 +266,7 @@ static INT_PTR CALLBACK Proc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 			GetDlgLogFont(GetParent(hWnd), ts, &dlg_data->DlgFont);
 			SetFontString(hWnd, IDC_DLGFONT_EDIT, &dlg_data->DlgFont);
 
-			DispSetLogFont(&dlg_data->VTFont, FALSE);
+			DispSetLogFont(&dlg_data->VTFont, 0);
 			SetFontString(hWnd, IDC_VTFONT_EDIT, &dlg_data->VTFont);
 
 			CheckDlgButton(hWnd,
@@ -321,7 +321,7 @@ static INT_PTR CALLBACK Proc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 										ts->FontDW = dlgw;
 										ts->FontDY = dlgy;
 										ts->FontDH = dlgh;
-										ChangeFont();
+										ChangeFont(0);
 										DispChangeWinSize(ts->TerminalWidth, ts->TerminalHeight);
 									}
 								}
@@ -330,7 +330,7 @@ static INT_PTR CALLBACK Proc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 					}
 
 					// ÉtÉHÉìÉgÇÃê›íË
-					ChangeFont();
+					ChangeFont(0);
 					DispChangeWinSize(WinWidth,WinHeight);
 					ChangeCaret();
 

--- a/teraterm/teraterm/vtdisp.h
+++ b/teraterm/teraterm/vtdisp.h
@@ -75,7 +75,7 @@ void DispConvWinToScreen
   (int Xw, int Yw, int *Xs, int *Ys, PBOOL Right);
 void DispConvScreenToWin
   (int Xs, int Ys, int *Xw, int *Yw);
-void ChangeFont(void);
+void ChangeFont(unsigned int dpi);
 void ResetIME(void);
 void ChangeCaret(void);
 void CaretKillFocus(BOOL show);
@@ -134,7 +134,7 @@ void DrawStrA(HDC DC, HDC BGDC, const char *StrA, const char *WidthInfo, int Cou
 			  int Y, int *X);
 void DispEnableResizedFont(BOOL enable);
 BOOL DispIsResizedFont();
-void DispSetLogFont(LOGFONTA *VTlf, BOOL mul);
+void DispSetLogFont(LOGFONTA *VTlf, unsigned int dpi);
 
 extern int WinWidth, WinHeight;
 extern HFONT VTFont[AttrFontMask+1];

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -451,7 +451,7 @@ CVTWindow::CVTWindow(HINSTANCE hInstance)
 		::PostMessage(HVTWin,WM_USER_CHANGEMENU,0,0);
 	}
 
-	ChangeFont();
+	ChangeFont(0);
 
 	ResetIME();
 
@@ -1020,7 +1020,7 @@ void CVTWindow::InitPasteMenu(HMENU *Menu)
 
 void CVTWindow::ResetSetup()
 {
-	ChangeFont();
+	ChangeFont(0);
 	BuffChangeWinSize(WinWidth,WinHeight);
 	ChangeCaret();
 
@@ -2451,7 +2451,7 @@ void CVTWindow::OnSize(WPARAM nType, int cx, int cy)
 			h = ts.TerminalHeight;
 
 			if (FontChanged) {
-				ChangeFont();
+				ChangeFont(0);
 			}
 		}
 		else {
@@ -4691,7 +4691,7 @@ LRESULT CVTWindow::OnDpiChanged(WPARAM wp, LPARAM lp)
 
 	// 新しいDPIに合わせてフォントを生成、
 	// クライアント領域のサイズを決定する
-	ChangeFont();
+	ChangeFont(NewDPI);
 	ScreenWidth = WinWidth * FontWidth;
 	ScreenHeight = WinHeight * FontHeight;
 	//AdjustScrollBar();


### PR DESCRIPTION
- Windows11 24H2 で発生
- DPIが異なるディスプレイをまたいでウィンドウを移動したとき、WM_DPICHANGED が送られてくる。 この時ウィンドウの表示されているディスプレイを調べると、またぐ前のディスプレイを返してくるため 誤ったDPIを元にフォントのサイズを決定していた
- WM_DPICHANGED メッセージと一緒に受け取る DPI は、またいだ後のディスプレイのDPIのようなので これを使ってフォントサイズを決定するようにした