### PR TITLE
ZMODEMの送信キャンセル時、処理が打ち切られないようにした

### DIFF
--- a/teraterm/teraterm/filesys_proto.cpp
+++ b/teraterm/teraterm/filesys_proto.cpp
@@ -791,12 +791,21 @@ void ProtoDlgTimeOut(void)
 	}
 }
 
+/**
+ *	ダイアログの "Cancel" が押された
+ */
 void ProtoDlgCancel(void)
 {
 	if (PtDlg!=NULL) {
 		PFileVarProto fv = FileVar;
+
+		// キャンセルが押されたことを通知する
 		fv->ProtoOp->Cancel(fv, &cv);
-		ProtoEnd();
+
+		if (ProtoId != PROTO_ZM) {
+			// ダイアログを閉じる
+			ProtoEnd();
+		}
 	}
 }
 


### PR DESCRIPTION
- キャンセルボタン押下後、
- CAN(0x18) x 8 + 0x08 x 10 を送信する処理を行うようにした
  - 従来は処理が打ち切られて送信されていなかった