### PR TITLE
chmファイルの文字化けを修正 #475

### DIFF
--- a/buildtools/install_sbapplocale.bat
+++ b/buildtools/install_sbapplocale.bat
@@ -1,0 +1,12 @@
+echo %~dp0\install_sbapplocale.bat
+
+pushd %~dp0
+
+if "%CMAKE_COMMAND%" == "" (
+   call ..\ci_scripts\find_cmake.bat
+)
+"%CMAKE_COMMAND%" -P install_sbapplocale.cmake
+
+popd
+
+if not "%NOPAUSE%" == "1" pause

--- a/buildtools/install_sbapplocale.cmake
+++ b/buildtools/install_sbapplocale.cmake
@@ -1,0 +1,39 @@
+﻿# cmake -P install_sbapplocale.cmake
+
+# sbapplocale
+set(SBAPPLOCALE_EXE "${CMAKE_CURRENT_LIST_DIR}/sbapplocale/sbapplocale.exe")
+set(SBAPPLOCALE_EXE_HASH "bcabc2d5ab34bff8f147d12b69e0a019d16cf6c06859ba765e4e68f20c948577")
+set(SBAPPLOCALE_URL "http://www.magicnotes.com/steelbytes/SBAppLocale_ENG.zip")
+set(SBAPPLOCALE_ZIP "${CMAKE_CURRENT_LIST_DIR}/download/sbapplocale/SBAppLocale_ENG.zip")
+set(SBAPPLOCALE_ZIP_HASH "e9edfd32cd5f03b36fac024f814ab8dd38e4880f3e6faacdea92d0e4d671fac1")
+
+# check sbapplocale
+if(EXISTS ${SBAPPLOCALE_EXE})
+  file(SHA256 ${SBAPPLOCALE_EXE} HASH)
+  if(${HASH} STREQUAL ${SBAPPLOCALE_EXE_HASH})
+    return()
+  endif()
+  message("file ${SBAPPLOCALE_EXE}")
+  message("actual HASH=${HASH}")
+  message("expect HASH=${SBAPPLOCALE_EXE_HASH}")
+endif()
+
+# download
+message("download ${SBAPPLOCALE_ZIP} from ${SBAPPLOCALE_URL}")
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/download/sbapplocale")
+file(DOWNLOAD
+  ${SBAPPLOCALE_URL}
+  ${SBAPPLOCALE_ZIP}
+  EXPECTED_HASH SHA256=${SBAPPLOCALE_ZIP_HASH}
+  SHOW_PROGRESS
+)
+
+# setup
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/sbapplocale")
+  file(REMOVE_RECURSE "${CMAKE_CURRENT_LIST_DIR}/sbapplocale")
+endif()
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/sbapplocale")
+file(ARCHIVE_EXTRACT
+  INPUT ${SBAPPLOCALE_ZIP}
+  DESTINATION "${CMAKE_CURRENT_LIST_DIR}/sbapplocale"
+)

--- a/buildtools/install_sbapplocale.md
+++ b/buildtools/install_sbapplocale.md
@@ -1,0 +1,9 @@
+﻿# SBAppLocale
+
+HTML help の文字化け対策のため使用
+- [真・HTML help文字化け対策](https://www.slideshare.net/slideshow/htmlhelp/12046823)
+
+次のプロジェクトを参考にしました
+- WinMerge
+  - [Commit a162a49](https://github.com/WinMerge/winmerge/commit/a162a491fbd25f62ea7f4ada562d9167107bae22)
+- TortoiseGit

--- a/doc/makechm.bat
+++ b/doc/makechm.bat
@@ -1,45 +1,37 @@
+setlocal
+
+set NOPAUSE=1
+call ..\buildtools\install_sbapplocale.bat
 
 if exist "%Programfiles(x86)%\HTML Help Workshop\hhc.exe" (
-	set HELP_COMPILER="%Programfiles(x86)%\HTML Help Workshop\hhc.exe"
+    set HELP_COMPILER="%Programfiles(x86)%\HTML Help Workshop\hhc.exe"
 ) else (
-	set HELP_COMPILER=C:\progra~1\htmlhe~1\hhc.exe
+    set HELP_COMPILER=C:\progra~1\htmlhe~1\hhc.exe
 )
 
 REM for winxp installation on other drive or other language
 if exist "%Programfiles%\HTML Help Workshop\hhc.exe" (
-set HELP_COMPILER="%Programfiles%\HTML Help Workshop\hhc.exe"
+    set HELP_COMPILER="%Programfiles%\HTML Help Workshop\hhc.exe"
 )
 
-if defined SystemRoot (
-    set FIND=%SystemRoot%\system32\find.exe
-    set CHCP=%SystemRoot%\system32\chcp.com
-) else (
-    set FIND=find.exe
-    set CHCP=chcp.exe
-)
-
-set updated=
+set SBAppLocale=..\buildtools\SBAppLocale\SBAppLocale.exe
 
 CALL convtext.bat
-
-REM Check Japanese version Windows
-if "%APPVEYOR%" == "True" goto JA
-%CHCP% | %FIND% "932" > NUL
-if NOT ERRORLEVEL 1 goto JA
-%CHCP% | %FIND% "65001" > NUL
-if NOT ERRORLEVEL 1 goto JA
-goto English
 
 :JA
 for /f "delims=" %%i in ('perl htmlhelp_update_check.pl ja teratermj.chm') do @set updated=%%i
 if "%updated%"=="updated" (
-perl htmlhelp_index_make.pl ja html -o ja\Index.hhk
-%HELP_COMPILER% ja\teraterm.hhp
+    perl htmlhelp_index_make.pl ja html -o ja\Index.hhk
+    %SBAppLocale% 1041 %HELP_COMPILER% ja\teraterm.hhp
 )
 
 :English
 for /f "delims=" %%i in ('perl htmlhelp_update_check.pl en teraterm.chm') do @set updated=%%i
 if "%updated%"=="updated" (
-perl htmlhelp_index_make.pl en html -o en\Index.hhk
-%HELP_COMPILER% en\teraterm.hhp
+    perl htmlhelp_index_make.pl en html -o en\Index.hhk
+    %SBAppLocale% 1033 %HELP_COMPILER% en\teraterm.hhp
 )
+
+endlocal
+
+if not "%NOPAUSE%" == "1" pause


### PR DESCRIPTION
- ヘルプコンパイラ(hhc.exe)の動作はOSの設定で変わるらしい
  - 英語Windows(非日本語Windows)で日本語ヘルプを作成すると文字化けが発生する
- 動作環境を調整するSBAppLocaleの上でhhcを動かして文字化けを回避する