### PR TITLE
telnet:// から起動されるときのコマンドに /E コマンドラインオプションを追加した #470

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -106,6 +106,12 @@
       <li>Upgraded Oniguruma to 6.9.10.</li>
       <li>Upgraded Inno Setup that is used for the installer to <a href="https://jrsoftware.org/files/is6-whatsnew.htm#6.4.0" target="_blank">6.4.0</a>.</li>
       <li>Upgraded TTSSH to <a href="#ttssh_3.4">3.4</a>.</li>
+      <li>Added /E option to command line, which is execute from TELNET protocol, that is associated by the installer.
+        <ul>
+          <li>Even if specified port number by URL is not 23, Telnet option negotiation is start.</li>
+          <li>Normally, Tera Term does not handle other than <a href="../usage/tips/not_port23.html">port 23</a> as TELNET.</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -106,6 +106,12 @@
       <li>Oniguruma 6.9.10へ差し替えた。</li>
       <li>インストーラに使用している Inno Setup のバージョンを<a href="https://jrsoftware.org/files/is6-whatsnew.htm#6.4.0" target="_blank">6.4.0</a>へ差し替えた。</li>
       <li><a href="#ttssh_3.4">TTSSH(3.4)</a>へ差し替えた。</li>
+      <li>インストーラによる TELNET プロトコルへの関連付けで、起動するコマンドラインオプションに /E を追加した。
+        <ul>
+          <li>これにより、URL で指定されたポート番号が 23 でなくても Telnet option negotiation が開始される。</li>
+          <li>Tera Term は通常 <a href="../usage/tips/not_port23.html">port 23</a> 以外を TELNET として扱わないため。</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/installer/teraterm.iss
+++ b/installer/teraterm.iss
@@ -186,7 +186,7 @@ Root: HKCU; Subkey: Software\Classes\TeraTerm.MacroFile\DefaultIcon; ValueType: 
 Root: HKCU; Subkey: Software\Classes\TeraTerm.MacroFile\shell\open\command; ValueType: string; ValueData: """{app}\ttpmacro.exe"" ""%1"""; Flags: uninsdeletekey; Components: TeraTerm; Tasks: macroassoc
 ; Associate with telnet://
 Root: HKCU; Subkey: Software\Classes\telnet\shell; ValueType: string; ValueData: Open with Tera Term; Flags: uninsclearvalue; Components: TeraTerm; Tasks: telnetassoc
-Root: HKCU; Subkey: Software\Classes\telnet\shell\Open with Tera Term\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /T=1 /nossh %1"; Flags: uninsdeletekey; Components: TeraTerm; Tasks: telnetassoc
+Root: HKCU; Subkey: Software\Classes\telnet\shell\Open with Tera Term\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /T=1 /nossh /E %1"; Flags: uninsdeletekey; Components: TeraTerm; Tasks: telnetassoc
 ; Associate with ssh://
 Root: HKCU; Subkey: Software\Classes\ssh; ValueType: string; ValueData: URL: SSH Protocol; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
 Root: HKCU; Subkey: Software\Classes\ssh; ValueName: URL Protocol; ValueType: string; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc


### PR DESCRIPTION
- 起動コマンドはインストーラによってレジストリに登録される
- Telnet option negotiation が開始されるようにするため
- telnet:// であるということは、port 23 ではなくても TELNET だから