### PR TITLE
ビルドエラー発生時に GitHub Actions でエラーにならないのを修正

### DIFF
--- a/ci_scripts/build_appveyor_release_bat.bat
+++ b/ci_scripts/build_appveyor_release_bat.bat
@@ -4,3 +4,7 @@ set CUR=%~dp0
 
 cd /d %CUR%..
 call installer\release.bat 2
+if ERRORLEVEL 1 (
+	echo installer\release.bat 2
+	exit 1
+)

--- a/installer/makearchive.bat
+++ b/installer/makearchive.bat
@@ -147,5 +147,4 @@ echo ===================================================
 echo.
 echo ƒrƒ‹ƒh‚ÉŽ¸”s‚µ‚Ü‚µ‚½ (Failed to build source code)
 endlocal
-exit /b
-
+exit 1

--- a/installer/release.bat
+++ b/installer/release.bat
@@ -113,8 +113,16 @@ if "%RELEASE%" == "1" (
 ) else (
     call makearchive.bat
 )
+if ERRORLEVEL 1 (
+	echo ERROR call makearchive.bat
+	exit /b 1
+)
 call iscc.bat
 
+if ERRORLEVEL 1 (
+	echo ERROR call iscc.bat
+	exit /b 1
+)
 endlocal
 exit /b 0
 

--- a/teraterm/teraterm/log_pp.cpp
+++ b/teraterm/teraterm/log_pp.cpp
@@ -492,7 +492,7 @@ void CLogPropPageDlg::OnOK()
 		ts.Append = 1;
 	}
 	else {
-		ts.Append = 0;
+		ts.Append = 0
 	}
 
 	if (GetCheck(IDC_OPT_PLAINTEXT)) {

--- a/teraterm/teraterm/log_pp.cpp
+++ b/teraterm/teraterm/log_pp.cpp
@@ -492,7 +492,7 @@ void CLogPropPageDlg::OnOK()
 		ts.Append = 1;
 	}
 	else {
-		ts.Append = 0
+		ts.Append = 0;
 	}
 
 	if (GetCheck(IDC_OPT_PLAINTEXT)) {


### PR DESCRIPTION
ビルドエラー発生時に GitHub Actions でエラーにならないのを修正

6febb9bc15b60c0dfc3e395cf9c0c13b77595b0e のコミットを入れて、意図的にビルドを失敗されたもの
ビルドに失敗しているけど、Actions 上でエラーになっていない。
https://github.com/m-tmatma/teraterm/actions/runs/13731158644

バッチファイルでエラーを返して、呼び出し元でエラーを返して、GitHub Actions 上でエラーと認識されるようにしたもの
https://github.com/m-tmatma/teraterm/actions/runs/13731170930

47d1e6f9cc3d5bdee57d79f86a85ed8aa1e45940 で 6febb9bc15b60c0dfc3e395cf9c0c13b77595b0e を revert して、意図的なエラーを解消したもの
https://github.com/m-tmatma/teraterm/actions/runs/13731176105

