### PR TITLE
CI の状態を確認できるように badge を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ﻿# Tera Term
 
+| CI | Workflow | Status |
+|----|----------|--------|
+| GitHub Actions | Build Installer | [![Build Status](https://github.com/TeraTermProject/teraterm/actions/workflows/msbuild.yml/badge.svg)](https://github.com/TeraTermProject/teraterm/actions/workflows/msbuild.yml) |
+
+
 Tera Term is a free software terminal emulator
 
 [URLs](https://github.com/TeraTermProject/teraterm/wiki/Urls)


### PR DESCRIPTION
CI の状態を確認できるように badge を追加する

こんな感じの表示になります。

https://github.com/m-tmatma/teraterm/tree/feature/add-badge

Badge はリンクになっていて、クリックすると Actions タブの該当の workflow に飛びます。

## 参考

appveyor にも同様の機能があります。
https://www.appveyor.com/docs/status-badges/

https://srz-zumix.blogspot.com/2015/03/appveyor-c-ci.html

> AppVeyor でもバッジが付けられます。
> プロジェクトの SETTINGS に Badges があるので、そこでバッジの URL がわかります。

設定メニューから URL を取得できます。


