### PR TITLE
成果物のアップロード処理を分離

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -63,13 +63,19 @@ jobs:
         chcp 932
         ci_scripts/build_appveyor_release_bat_pre_cache.bat
 
-    - name: Upload artifacts
+    - name: Upload artifacts (zip)
+      uses: actions/upload-artifact@v4
+      with:
+        name: binary-BUILD-${{ github.run_number }}-${{ github.run_id }}-VS${{ matrix.VS_VERSION }}
+        path: |
+          installer/Output/*.zip
+
+    - name: Upload artifacts (exe)
       uses: actions/upload-artifact@v4
       with:
         name: installer-BUILD-${{ github.run_number }}-${{ github.run_id }}-VS${{ matrix.VS_VERSION }}
         path: |
           installer/Output/*.exe
-          installer/Output/*.zip
 
     - name: Save libs
       id: cache-libs-save


### PR DESCRIPTION
成果物のアップロード処理を分離

インストーラ (exe) とバイナリおよび pdb(zip) を別々の artifacts としてアップロードします。
インストーラだけほしいときに、すべてダウンロードするのは無駄なためです。