### PR TITLE
文字選択時、マウスポインタが文字の右側か左側かを考慮するよう修正 #468

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -61,6 +61,11 @@
         Fixed Corrected Sequences OSC 4 259 to reverse attribute text color setting (was set to background color setting)
         (<a href="https://github.com/TeraTermProject/teraterm/issues/532" target="_blank">issue #532</a>)
       </li>
+      <li>
+        Fixed to take into account left and right sides of characters when selecting characters with mouse.
+        The same behavior as before Tera Term 5.1.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/468" target="_blank">issue #468</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -59,6 +59,11 @@
         シーケンス OCS 4 259を反転属性の文字色設定に修正した(背景色設定になっていた)
         (<a href="https://github.com/TeraTermProject/teraterm/issues/532" target="_blank">issue #532</a>)
       </li>
+      <li>
+        マウスで文字を選択するとき、文字の左右を考慮するよう修正した。
+        Tera Term 5.1以前の動作となった。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/468" target="_blank">issue #468</a>)
+      </li>
     </ul>
   </li>
 


### PR DESCRIPTION
- 5.2より前と同じ動作になった
- 2cellより大きな文字も考慮した