### PR TITLE
タスクスケジューラから実行できないことがあったので修正 #196

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -80,6 +80,10 @@
           <li>Even if the screen resolution is not 96 DPI, adjusted so that the point size selected in the font selection dialog matches the value for 96 DPI.</li>
         </ul>
       </li>
+      <li>
+        MACRO: Fixed the issue where macro could not be executed through the task scheduler.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/196" target="_blank">issue #196</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -80,6 +80,10 @@
           <li>画面の解像度が96DPI以外の場合でも、フォント選択ダイアログで選択したポイントサイズが96DPIの場合の値と同じになるよう修正した。</li>
         </ul>
       </li>
+      <li>
+        MACRO: タスクスケジューラ経由でマクロを実行出来ない不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/196" target="_blank">issue #196</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/ttpmacro/ttmacro.cpp
+++ b/teraterm/ttpmacro/ttmacro.cpp
@@ -150,17 +150,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 
 	// message pump
 	MSG msg;
-	while (GetMessage(&msg, NULL, 0, 0)) {
+	for (;;) {
+		// Windowsのメッセージがない場合のループ
+		for(;;) {
+			if (PeekMessageA(&msg, NULL, NULL, NULL, PM_NOREMOVE) != FALSE) {
+				// メッセージが存在した、ループを抜ける
+				break;
+			}
 
-		if (IsDialogMessage(hWnd, &msg) != 0) {
-			/* 処理された*/
-		} else {
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-		}
-
-		while (!PeekMessage(&msg, NULL, NULL, NULL, PM_NOREMOVE)) {
-			// メッセージがない
 			if (!OnIdle(lCount)) {
 				// idle不要
 				if (SleepTick < 500) {	// 最大 501ms未満
@@ -174,7 +171,27 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 				lCount++;
 			}
 		}
+
+		// Windowsのメッセージが空になるまで処理する
+		for(;;) {
+			if (GetMessageW(&msg, NULL, 0, 0) == FALSE) {
+				// WM_QUIT
+				goto exit_message_loop;
+			}
+			if (IsDialogMessageW(hWnd, &msg) != 0) {
+				/* 処理された*/
+			} else {
+				TranslateMessage(&msg);
+				DispatchMessageW(&msg);
+			}
+
+			if (PeekMessageA(&msg, NULL, NULL, NULL, PM_NOREMOVE) == FALSE) {
+				// メッセージがなくなった、ループを抜ける
+				break;
+			}
+		}
 	}
+exit_message_loop:
 
 	pCCtrlWindow->DestroyWindow();
 	delete pCCtrlWindow;


### PR DESCRIPTION
- 「ユーザーがログオンしているかどうかにかかわらず実行する」= ON 時
- メッセージポンプとアイドル処理を連続して実行できるようにした
  - GetMessage()でブロックしないようにした