### PR TITLE
コンパイラの警告対策

### DIFF
--- a/teraterm/common/comportinfo.cpp
+++ b/teraterm/common/comportinfo.cpp
@@ -344,7 +344,6 @@ static ComPortInfo_t *ComPortInfoGetByGetSetupAPI(int *count)
 			info.class_name = class_str;
 			GetComProperty(hDevInfo, &DeviceInfoData, &info);
 			CreatePropertyStr(&info);
-			int port_no = 0;
 			if (wcsncmp(port_name, L"COM", 3) == 0) {
 				info.port_no = _wtoi(port_name + 3);
 			}

--- a/teraterm/common/dlglib_tmpl.cpp
+++ b/teraterm/common/dlglib_tmpl.cpp
@@ -30,13 +30,13 @@
 
 #include "dlglib.h"
 
-#include <wchar.h>
-#include <assert.h>
 #if !defined(_CRTDBG_MAP_ALLOC)
 #define _CRTDBG_MAP_ALLOC
 #endif
 #include <stdlib.h>
 #include <crtdbg.h>
+#include <wchar.h>
+#include <assert.h>
 
 // https://docs.microsoft.com/ja-jp/windows/desktop/dlgbox/dlgtemplateex
 // https://www.pg-fl.jp/program/tips/dlgmem.htm

--- a/teraterm/common/history_store.cpp
+++ b/teraterm/common/history_store.cpp
@@ -252,8 +252,9 @@ void HistoryStoreSetControl(HistoryStore *h, HWND dlg, int dlg_item)
 
 void HistoryStoreGetControl(HistoryStore *h, HWND dlg, int dlg_item)
 {
-	LRESULT item_count;
-	LRESULT i;
+	LRESULT getcount_result;
+	size_t item_count;
+	size_t i;
 	char class_name[32];
 	UINT GETCOUNT;
 	int r = GetClassNameA(GetDlgItem(dlg, dlg_item), class_name, _countof(class_name));
@@ -268,10 +269,11 @@ void HistoryStoreGetControl(HistoryStore *h, HWND dlg, int dlg_item)
 		return;
 	}
 
-	item_count = SendDlgItemMessageW(dlg, dlg_item, GETCOUNT, 0, 0);
-	if (item_count == LB_ERR) {
+	getcount_result = SendDlgItemMessageW(dlg, dlg_item, GETCOUNT, 0, 0);
+	if (getcount_result == LB_ERR) {
 		return;
 	}
+	item_count = (size_t)getcount_result;
 	if (item_count > h->max) {
 		item_count = h->max;
 	}

--- a/teraterm/common/tipwin.cpp
+++ b/teraterm/common/tipwin.cpp
@@ -57,12 +57,13 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include <wchar.h>
-#include <assert.h>
 #if !defined(_CRTDBG_MAP_ALLOC)
 #define _CRTDBG_MAP_ALLOC
 #endif
+#include <stdlib.h>
 #include <crtdbg.h>
+#include <wchar.h>
+#include <assert.h>
 
 #include "ttlib.h"		// for GetMessageboxFont()
 #include "codeconv.h"

--- a/teraterm/common/tmfc_propdlg.cpp
+++ b/teraterm/common/tmfc_propdlg.cpp
@@ -28,10 +28,10 @@
 
 #include <windows.h>
 #include <commctrl.h>
-#include <wchar.h>
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
 #include <crtdbg.h>
+#include <wchar.h>
 
 #include "ttlib.h"
 #include "dlglib.h"

--- a/teraterm/ttpcmn/ttcmn_notify.cpp
+++ b/teraterm/ttpcmn/ttcmn_notify.cpp
@@ -36,13 +36,13 @@
 #endif
 #endif
 
-#include <string.h>
 #include <windows.h>
-#include <wchar.h>
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
 #include <crtdbg.h>
 #include <assert.h>
+#include <string.h>
+#include <wchar.h>
 
 #include "teraterm.h"
 #include "tttypes.h"


### PR DESCRIPTION
- warning C4005: '_malloca': マクロが再定義されました。
  - Debug時
- warning C4189: 'port_no': ローカル変数が初期化されましたが、参照されていません
- warning C4018: '>': signed と unsigned の数値を比較しようとしました。

変更履歴 不要
port 不要