### PR TITLE
行末に"能"を置かないよう修正

### DIFF
--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -5082,7 +5082,7 @@ LRESULT CVTWindow::OnDpiChanged(WPARAM wp, LPARAM lp, BOOL calcOnly)
 									r->left, r->top, NewWindowWidth, NewWindowHeight,
 									NULL, (HMENU)0x00, m_hInst, (LPVOID)NULL);
 			if (tmphWnd) {
-				assert(pGetDpiForWindow); // GetDpiForWindow()は、Windows 10 v1607 Red Stone 1 (RS1)以降で使用可能
+				assert(pGetDpiForWindow); // GetDpiForWindow()は、Windows 10 v1607 Red Stone 1 (RS1)以降で使用可能_
 				int myDPI = pGetDpiForWindow(tmphWnd);
 				/*
 				  ・Tera Term の高 DPI(Per-Monitor V2) 対応環境は、Windows 10 v1703 以降。


### PR DESCRIPTION
- ソースコードはShift_JIS、"能"の2byte目が"\"となる
- 次の行と連結してしまい、コメントアウトされる
- gccでビルドした場合処理発生
  - 入力文字コード未指定時、UTF-8として処理される
  - VSでも日本語環境以外で問題が起きるかも

変更履歴 不要
port 不要