### PR TITLE
ディスプレイのDPI取得を誤っている場合がある #555 (VTWin最大化時の不具合修正)

### DIFF
--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -4957,17 +4957,6 @@ LRESULT CVTWindow::OnDpiChanged(WPARAM wp, LPARAM lp, BOOL calcOnly)
 	int NewWindowWidth;
 	int NewWindowHeight;
 
-#ifdef WINDOW_MAXMIMUM_ENABLED
-	if (IsZoomed(m_hWnd)) {
-		if (calcOnly) {
-			return FALSE;
-		}
-		GetDesktopRect(m_hWnd, &NewWindowRect[0]);
-		NewRect = &NewWindowRect[0];
-		NewWindowWidth  = NewRect->right  - NewRect->left;
-		NewWindowHeight = NewRect->bottom - NewRect->top;
-	} else
-#endif
 	if (isSizing && (calcOnly == FALSE)) {
 		NewRect = &SuggestedWindowRect;
 		NewWindowWidth  = NewRect->right  - NewRect->left;
@@ -5114,6 +5103,17 @@ LRESULT CVTWindow::OnDpiChanged(WPARAM wp, LPARAM lp, BOOL calcOnly)
 			}
 		}
 	}
+
+#ifdef WINDOW_MAXMIMUM_ENABLED
+	if (IsZoomed(m_hWnd)) {
+		ts.TerminalOldWidth = NewWindowWidth;
+		ts.TerminalOldHeight = NewWindowHeight;
+		GetDesktopRect(m_hWnd, &NewWindowRect[0]);
+		NewRect = &NewWindowRect[0];
+		NewWindowWidth  = NewRect->right  - NewRect->left;
+		NewWindowHeight = NewRect->bottom - NewRect->top;
+	}
+#endif
 
 	::SetWindowPos(m_hWnd, NULL,
 				   NewRect->left, NewRect->top,


### PR DESCRIPTION
ディスプレイのDPI取得を誤っている場合がある #555 につきまして、
VTWinを最大化した状態でDPIに変化があった場合にフォントサイズがDPIに応じたサイズにならない不具合の修正パッチをお送りさせて頂きます。