### PR TITLE
ディスプレイのDPI取得を誤っている場合がある(VTWindow最大化時の描画崩れの修正) #555

### DIFF
--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -2767,14 +2767,8 @@ void CVTWindow::OnSize(WPARAM nType, int cx, int cy)
 			}
 		}
 		else {
-			if (isSizing) {
-				// ウィンドウがリサイズした
-				w = cx / FontWidth;
-				h = cy / FontHeight;
-			} else {
-				// ウィンドウが移動した
-				return;
-			}
+			w = cx / FontWidth;
+			h = cy / FontHeight;
 		}
 
 		HideStatusLine();


### PR DESCRIPTION
VT window を最大化した場合に描画が崩れるため、行/列数の更新処理を元の処理に戻す修正になります。
