### PR TITLE
Tera Term マクロで cygconnect を実行すると「/D=XXXXXXXX\n指定されたファイルがみつかりません。」と表示され、cygterm が起動しない。 #645

### DIFF
--- a/cygwin/cygterm/cygterm.cpp
+++ b/cygwin/cygterm/cygterm.cpp
@@ -722,7 +722,7 @@ DWORD WINAPI term_thread(LPVOID param)
 	asprintf(&term, cfg->term, inet_ntoa(addr), (int)ntohs(listen_port));
 	if (cfg->termopt != NULL) {
 		char *tmp;
-		asprintf(&tmp, "%s %s", tmp, cfg->termopt);
+		asprintf(&tmp, "%s %s", term, cfg->termopt);
 		free(term);
 		term = tmp;
 	}
@@ -749,8 +749,10 @@ DWORD WINAPI term_thread(LPVOID param)
 	free(termT);
 	if (!r) {
 		api_error(term);
+		free(term);
 		return 0;
 	}
+	free(term);
 	WaitForSingleObject(pi.hProcess, INFINITE);
 	CloseHandle(pi.hProcess);
 	CloseHandle(pi.hThread);

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -142,9 +142,7 @@
       </li>
       <li>Added <a href="#changefontsize_1.00">TTXChangeFontSize</a>.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/599" target="_blank">issue #599</a>)</li>
-      <li>upgraded CygTerm+ to <a href="#cygterm_1.07_30">1.07_30</a>
-        (<a href="https://github.com/TeraTermProject/teraterm/issues/645" target="_blank">issue #645</a>)
-      </li>
+      <li>Upgraded CygTerm+ to <a href="#cygterm_1.07_30">1.07_30</a>.</li>
     </ul>
   </li>
 </ul>
@@ -5353,7 +5351,10 @@ SYNOPSIS:
 <h2 id="cygterm">CygTerm+</h2>
 <h3 id="cygterm_1.07_30">v1.07_30 YYYY/MM/DD (not released yet)</h3>
 <ul class="history">
-      <li>The issue where executing cygconnect in the Tera Term macro resulted in the message "/D=XXXXXXXX\nThe specified file could not be found" and prevented Cygterm from launching has been fixed.</li>
+      <li>
+        The issue where executing cygconnect in the Tera Term macro resulted in the message "/D=XXXXXXXX\nThe specified file could not be found" and prevented Cygterm from launching has been fixed.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/645" target="_blank">issue #645</a>)
+      </li>
 </ul>
 
 <h3 id="cygterm_1.07_29">v1.07_29 2016/11/26 (by maya)</h3>

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -140,8 +140,6 @@
         installer: Tera Term now appears as a candidate for "Default apps" of protocol and file extension.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/471" target="_blank">issue #471</a>)
       </li>
-      <li>Added <a href="#changefontsize_1.00">TTXChangeFontSize</a>.
-        (<a href="https://github.com/TeraTermProject/teraterm/issues/599" target="_blank">issue #599</a>)</li>
       <li>Upgraded CygTerm+ to <a href="#cygterm_1.07_30">1.07_30</a>.</li>
       <li>Added <a href="#changefontsize_1.00">TTXChangeFontSize</a>.</li>
     </ul>

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -142,6 +142,9 @@
       </li>
       <li>Added <a href="#changefontsize_1.00">TTXChangeFontSize</a>.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/599" target="_blank">issue #599</a>)</li>
+      <li>upgraded CygTerm+ to <a href="#cygterm_1.07_30">1.07_30</a>
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/645" target="_blank">issue #645</a>)
+      </li>
     </ul>
   </li>
 </ul>
@@ -5348,6 +5351,10 @@ SYNOPSIS:
 
 
 <h2 id="cygterm">CygTerm+</h2>
+<h3 id="cygterm_1.07_30">v1.07_30 YYYY/MM/DD (not released yet)</h3>
+<ul class="history">
+      <li>The issue where executing cygconnect in the Tera Term macro resulted in the message "/D=XXXXXXXX\nThe specified file could not be found" and prevented Cygterm from launching has been fixed.</li>
+</ul>
 
 <h3 id="cygterm_1.07_29">v1.07_29 2016/11/26 (by maya)</h3>
 <ul class="history">

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -140,8 +140,6 @@
         インストーラ: Tera Term がプロトコルや拡張子の「既定のアプリ」の候補に出てくるようにした。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/471" target="_blank">issue #471</a>)
       </li>
-      <li><a href="#changefontsize_1.00">TTXChangeFontSize</a>を追加した。
-        (<a href="https://github.com/TeraTermProject/teraterm/issues/599" target="_blank">issue #599</a>)</li>
       <li><a href="#cygterm_1.07_30">CygTerm+ 1.07_30</a>へ差し替えた。</li>
       <li><a href="#changefontsize_1.00">TTXChangeFontSize</a>を追加した。</li>
     </ul>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -142,6 +142,9 @@
       </li>
       <li><a href="#changefontsize_1.00">TTXChangeFontSize</a>を追加した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/599" target="_blank">issue #599</a>)</li>
+      <li><a href="#cygterm_1.07_30">CygTerm+ 1.07_30</a>へ差し替えた。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/645" target="_blank">issue #645</a>)
+      </li>
     </ul>
   </li>
 </ul>
@@ -5355,6 +5358,10 @@
 
 
 <h2 id="cygterm">CygTerm+</h2>
+<h3 id="cygterm_1.07_30">v1.07_30 YYYY/MM/DD (not released yet)</h3>
+<ul class="history">
+      <li>Tera Term マクロで cygconnect を実行すると「/D=XXXXXXXX\n指定されたファイルがみつかりません。」と表示され、cygterm が起動しない不具合を修正した。</li>
+</ul>
 
 <h3 id="cygterm_1.07_29">v1.07_29 2016/11/26 (by maya)</h3>
 <ul class="history">

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -142,9 +142,7 @@
       </li>
       <li><a href="#changefontsize_1.00">TTXChangeFontSize</a>を追加した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/599" target="_blank">issue #599</a>)</li>
-      <li><a href="#cygterm_1.07_30">CygTerm+ 1.07_30</a>へ差し替えた。
-        (<a href="https://github.com/TeraTermProject/teraterm/issues/645" target="_blank">issue #645</a>)
-      </li>
+      <li><a href="#cygterm_1.07_30">CygTerm+ 1.07_30</a>へ差し替えた。</li>
     </ul>
   </li>
 </ul>
@@ -5360,7 +5358,10 @@
 <h2 id="cygterm">CygTerm+</h2>
 <h3 id="cygterm_1.07_30">v1.07_30 YYYY/MM/DD (not released yet)</h3>
 <ul class="history">
-      <li>Tera Term マクロで cygconnect を実行すると「/D=XXXXXXXX\n指定されたファイルがみつかりません。」と表示され、cygterm が起動しない不具合を修正した。</li>
+      <li>
+        Tera Term マクロで cygconnect を実行すると「/D=XXXXXXXX\n指定されたファイルがみつかりません。」と表示され、cygterm が起動しない不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/645" target="_blank">issue #645</a>)
+      </li>
 </ul>
 
 <h3 id="cygterm_1.07_29">v1.07_29 2016/11/26 (by maya)</h3>


### PR DESCRIPTION
#645 Cygterm+ の -o オプション指定時の処理誤りの修正パッチをお送りさせて頂きます。