### PR TITLE
Mfc/#547

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -3683,11 +3683,14 @@ SYNOPSIS:
     </ul>
   </li-->
 
-  <!--li>Bug fixes
+  <li>Bug fixes
     <ul>
-      <li></li>
+      <li>
+        Fixed the version number of TTSSH that is sent to SSH server. x.y.z format is sent now. x.y format was used.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/547" target="_blank">issue #547</a>)
+        </li>
     </ul>
-  </li-->
+  </li>
 
   <!--li>Misc
     <ul>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -3691,11 +3691,14 @@
     </ul>
   </li-->
 
-  <!--li>バグ修正
+  <li>バグ修正
     <ul>
-      <li></li>
+      <li>
+        サーバに送信する TTSSH のバージョン番号を x.y.z 形式で送信するように修正した。x.y 形式になっていた。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/547" target="_blank">issue #547</a>)
+        </li>
     </ul>
-  </li-->
+  </li>
 
   <!--li>その他
     <ul>

--- a/ttssh2/ttxssh/ssh.c
+++ b/ttssh2/ttxssh/ssh.c
@@ -2054,22 +2054,22 @@ BOOL SSH_handle_server_ID(PTInstVar pvar, char *ID, int ID_len)
 				int TTSSH_ID_len;
 
 				// SSH バージョンを teraterm 側にセットする
-				// SCP コマンドのため (2008.2.3 maya)
+				// SCP コマンドのため (2008.2.3)
 				pvar->cv->isSSH = pvar->protocol_major;
 
-				// 自分自身のバージョンを取得する (2005.3.3 yutaka)
+				// 自分自身のバージョンを取得する (2005.3.3)
 				_snprintf_s(TTSSH_ID, sizeof(TTSSH_ID), _TRUNCATE,
-				            "SSH-%d.%d-TTSSH/%d.%d Win32\r\n",
+				            "SSH-%d.%d-TTSSH/%d.%d.%d Win32\r\n",
 				            pvar->protocol_major, pvar->protocol_minor,
-				            TTSSH_VERSION_MAJOR, TTSSH_VERSION_MINOR);
+				            TTSSH_VERSION_MAJOR, TTSSH_VERSION_MINOR, TTSSH_VERSION_PATCH);
 				TTSSH_ID_len = strlen(TTSSH_ID);
 
-				// for SSH2(yutaka)
+				// for SSH2
 				// クライアントバージョンの保存（改行は取り除くこと）
 				strncpy_s(pvar->client_version_string, sizeof(pvar->client_version_string),
 				          TTSSH_ID, _TRUNCATE);
 
-				// サーババージョンの保存（改行は取り除くこと）(2005.3.9 yutaka)
+				// サーババージョンの保存（改行は取り除くこと）(2005.3.9)
 				_snprintf_s(pvar->server_version_string,
 				            sizeof(pvar->server_version_string), _TRUNCATE,
 				            "%s", pvar->ssh_state.server_ID);


### PR DESCRIPTION
サーバに送信する TTSSH のバージョン文字列を x.y.z になるように修正 #547