### PR TITLE
Multiple config files don't work --- windows using ..\teraterm5\ttermpro.exe /F=FILE #653

### DIFF
--- a/TTProxy/TTProxy.h
+++ b/TTProxy/TTProxy.h
@@ -68,25 +68,17 @@ private:
 		IniFile inifile(filename, "TTProxy");
 		ProxyWSockHook::save(inifile);
 	}
-	static String get_teraterm_dir_relative_name(char* basename) {
-		if (!IsRelativePathA(basename)) {
-			return basename;
-		}
-		char buf[1024];
-		::GetModuleFileName(NULL, buf, sizeof buf);
-		char* filename = NULL;
-		for (char* dst = buf; *dst != '\0'; dst++) {
-			if (*dst == '\\' || *dst == '/' || *dst == ':') {
-				filename = dst + 1;
-			}
-		}
-		if (filename == NULL)
-			return basename;
+	static wchar_t *get_home_dir_relative_nameW(const wchar_t *basename) {
+		wchar_t *full_path = NULL, *dir;
 
-		*filename = '\0';
-		StringBuffer buffer(buf);
-		buffer.append(basename);
-		return buffer.toString();
+		if (!IsRelativePathW(basename)) {
+			return _wcsdup(basename);
+		}
+
+		dir = GetHomeDirW(NULL);
+		awcscats(&full_path, dir, L"\\", basename, NULL);
+		free(dir);
+		return full_path;
 	}
 
 	static void PASCAL TTXReadINIFile(const wchar_t *fileName, PTTSet ts) {
@@ -117,12 +109,11 @@ private:
 
 			if ((option[0] == '-' || option[0] == '/')) {
 				if ((option[1] == 'F' || option[1] == 'f') && option[2] == '=') {
-					char *optA = ToCharW(option + 3);
-					String f = get_teraterm_dir_relative_name(optA);
-					free(optA);
-					wchar_t *fW = ToWcharA(f);
-					read_options(fW);
-					free(fW);
+					if (option[3] != NULL) {
+						wchar_t *f = get_home_dir_relative_nameW(option + 3);
+						read_options(f);
+						free(f);
+					}
 				}
 			}
 

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -142,6 +142,7 @@
       </li>
       <li>Upgraded CygTerm+ to <a href="#cygterm_1.07_30">1.07_30</a>.</li>
       <li>Added <a href="#changefontsize_1.00">TTXChangeFontSize</a>.</li>
+      <li>Upgraded TTProxy to <a href="#ttproxy_1.0.0.27">1.0.0.27</a>.</li>
     </ul>
   </li>
 </ul>
@@ -5613,14 +5614,16 @@ SYNOPSIS:
 
 <h2 id="ttproxy">TTProxy</h2>
 
+<h3 id="ttproxy_1.0.0.27">YYYY.MM.DD (Ver 1.0.0.27 not released yet)</h3>
+<ul class="history">
+      <li>
+        The issue where the relative path specified by the Tera Term command line option /F=<setup file> was not treated as a relative path from %APPDATA%\teraterm5 has been fixed.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/653" target="_blank">issue #653</a>)
+      </li>
+</ul>
+
 <h3 id="ttproxy_1.0.0.26">2019.12.7 (Ver 1.0.0.26)</h3>
 <ul class="history">
-  <!-- li>Changes
-    <ul>
-      <li></li>
-    </ul>
-  </li -->
-
   <li>Bug fixes
     <ul>
       <li>When the HTTP proxy connection fails and the status code is other than 400,401,403,405,406,407, invalid string is shown in the message box.</li>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -142,6 +142,7 @@
       </li>
       <li><a href="#cygterm_1.07_30">CygTerm+ 1.07_30</a>へ差し替えた。</li>
       <li><a href="#changefontsize_1.00">TTXChangeFontSize</a>を追加した。</li>
+      <li><a href="#ttproxy_1.0.0.27">TTProxy 1.0.0.27</a>へ差し替えた。</li>
     </ul>
   </li>
 </ul>
@@ -5620,14 +5621,16 @@
 
 <h2 id="ttproxy">TTProxy</h2>
 
+<h3 id="ttproxy_1.0.0.27">YYYY.MM.DD (Ver 1.0.0.27 not released yet)</h3>
+<ul class="history">
+      <li>
+        Tera Term のコマンドラインオプション /F=<setup file> で相対パスが指定された場合に %APPDATA%\teraterm5\ からの相対パスと見なされない不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/653" target="_blank">issue #653</a>)
+      </li>
+</ul>
+
 <h3 id="ttproxy_1.0.0.26">2019.12.7 (Ver 1.0.0.26)</h3>
 <ul class="history">
-  <!--li>変更
-    <ul>
-      <li></li>
-    </ul>
-  </li -->
-
   <li>バグ修正
     <ul>
       <li>HTTPプロキシ接続がエラーとなり、ステータスコードが400,401,403,405,406,407以外だった場合、メッセージボックスにゴミが表示される問題を修正した。</li>


### PR DESCRIPTION
Tera Term のコマンドラインオプション /F=<setup file> で相対パスが指定された場合に %APPDATA%\teraterm5\ からの相対パスと見なされない不具合の修正パッチをお送りさせて頂きます。