### PR TITLE
タスクスケジューラから実行できないことがあったので修正 #196

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -79,6 +79,9 @@
           <li>When selecting a font size larger than the current font, the window size exceeds that of the desktop.</li>
         </ul>
       </li>
+        MACRO: Fixed the issue where macro could not be executed through the task scheduler.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/196" target="_blank">issue #196</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -79,6 +79,9 @@
           <li>使用中のフォントより大きいフォントサイズを選択するとウィンドウサイズがデスクトップより大きくなる。</li>
         </ul>
       </li>
+        MACRO: タスクスケジューラ経由でマクロを実行出来ない不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/196" target="_blank">issue #196</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/ttpmacro/ttmacro.cpp
+++ b/teraterm/ttpmacro/ttmacro.cpp
@@ -150,17 +150,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 
 	// message pump
 	MSG msg;
-	while (GetMessage(&msg, NULL, 0, 0)) {
+	for (;;) {
+		// Windowsのメッセージがない場合のループ
+		for(;;) {
+			if (PeekMessageA(&msg, NULL, NULL, NULL, PM_NOREMOVE) != FALSE) {
+				// メッセージが存在した、ループを抜ける
+				break;
+			}
 
-		if (IsDialogMessage(hWnd, &msg) != 0) {
-			/* 処理された*/
-		} else {
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-		}
-
-		while (!PeekMessage(&msg, NULL, NULL, NULL, PM_NOREMOVE)) {
-			// メッセージがない
 			if (!OnIdle(lCount)) {
 				// idle不要
 				if (SleepTick < 500) {	// 最大 501ms未満
@@ -174,7 +171,27 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 				lCount++;
 			}
 		}
+
+		// Windowsのメッセージが空になるまで処理する
+		for(;;) {
+			if (GetMessageW(&msg, NULL, 0, 0) == FALSE) {
+				// WM_QUIT
+				goto exit_message_loop;
+			}
+			if (IsDialogMessageW(hWnd, &msg) != 0) {
+				/* 処理された*/
+			} else {
+				TranslateMessage(&msg);
+				DispatchMessageW(&msg);
+			}
+
+			if (PeekMessageA(&msg, NULL, NULL, NULL, PM_NOREMOVE) == FALSE) {
+				// メッセージがなくなった、ループを抜ける
+				break;
+			}
+		}
 	}
+exit_message_loop:
 
 	pCCtrlWindow->DestroyWindow();
 	delete pCCtrlWindow;


### PR DESCRIPTION
タスクスケジューラから実行できないことがあったので修正 #196

- 「ユーザーがログオンしているかどうかにかかわらず実行する」= ON 時
- メッセージポンプとアイドル処理を連続して実行できるようにした
  - GetMessage()でブロックしないようにした