### PR TITLE
Mfc/#648

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -86,6 +86,10 @@
         Fixed the bug where Tera Term crashes when a filename using ':' in a location other than the drive letter is specified in the logopen of the Tera Term macro.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/648" target="_blank">issue #648</a>)
       </li>
+      <li>
+        Fixed Tera Term may stop working when Tera Term macro is executed in hidden mode and Tera Term is executed by <a href="../macro/command/connect.html">connect</a> macro command.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/607" target="_blank">issue #607</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -82,6 +82,10 @@
         MACRO: Fixed the issue where macro could not be executed through the task scheduler.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/196" target="_blank">issue #196</a>)
       </li>
+      <li>
+        Fixed the bug where Tera Term crashes when a filename using ':' in a location other than the drive letter is specified in the logopen of the Tera Term macro.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/648" target="_blank">issue #648</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -82,6 +82,10 @@
         MACRO: ã‚¿ã‚¹ã‚¯ã‚¹ã‚±ã‚¸ãƒ¥ãƒ¼ãƒ©çµŒç”±ã§ãƒžã‚¯ãƒ­ã‚’å®Ÿè¡Œå‡ºæ¥ãªã„ä¸å…·åˆã‚’ä¿®æ­£ã—ãŸã€‚
         (<a href="https://github.com/TeraTermProject/teraterm/issues/196" target="_blank">issue #196</a>)
       </li>
+      <li>
+        Tera Term ƒ}ƒNƒ‚Ì logopen ‚Åƒhƒ‰ƒCƒuƒŒƒ^[ˆÈŠO‚ÌêŠ‚É":"‚ðŽg—p‚µ‚½ƒtƒ@ƒCƒ‹–¼‚ðŽw’è‚µ‚½ê‡‚ÉATera Term ‚ªƒNƒ‰ƒbƒVƒ…‚·‚é•s‹ï‡‚ðC³‚µ‚½B
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/648" target="_blank">issue #648</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -86,6 +86,10 @@
         Tera Term マクロの logopen でドライブレター以外の場所に":"を使用したファイル名を指定した場合に、Tera Term がクラッシュする不具合を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/648" target="_blank">issue #648</a>)
       </li>
+      <li>
+        Tera Termマクロを非表示で実行して、<a href="../macro/command/connect.html">connect</a>マクロコマンドでTera Termを起動すると動作が停止する場合があったので修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/607" target="_blank">issue #607</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/common/ttlib_static_cpp.cpp
+++ b/teraterm/common/ttlib_static_cpp.cpp
@@ -989,8 +989,10 @@ wchar_t *ExtractDirNameW(const wchar_t *PathName)
 {
 	size_t i;
 	wchar_t *DirName = _wcsdup(PathName);
-	if (!GetFileNamePosW(DirName, &i, NULL))
+	if (!GetFileNamePosW(DirName, &i, NULL)) {
+		free(DirName);
 		return NULL;
+	}
 	DirName[i] = 0;
 	return DirName;
 }

--- a/teraterm/teraterm/filesys_log.cpp
+++ b/teraterm/teraterm/filesys_log.cpp
@@ -1068,6 +1068,9 @@ wchar_t *FLogGetLogFilename(const wchar_t *log_filename)
 	else if (!IsRelativePathW(log_filename)) {
 		// â‘ÎƒpƒX‚ª“ü—Í‚³‚ê‚½
 		dir = ExtractDirNameW(log_filename);
+		if (dir == NULL) {
+			return NULL;
+		}
 		fname = ExtractFileNameW(log_filename);
 	}
 	else {

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -740,10 +740,16 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 			result = DDE_FNOTPROCESSED;
 		}
 		else {
+			BOOL ret;
+
 			wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
 			wchar_t *log_filenameW = FLogGetLogFilename(ParamFileNameW);
-			BOOL ret = FLogOpen(log_filenameW, LOG_UTF8, FALSE);
-			free(log_filenameW);
+			if (log_filenameW == NULL) {
+				ret = 0;
+			} else {
+				ret = FLogOpen(log_filenameW, LOG_UTF8, FALSE);
+				free(log_filenameW);
+			}
 			free(ParamFileNameW);
 			strncpy_s(ParamFileName, sizeof(ParamFileName), ret ? "1" : "0", _TRUNCATE);
 		}


### PR DESCRIPTION
Tera Term マクロの logopen で指定するファイル名に、ドライブレター以外で:を使用した場合にクラッシュする不具合を修正した #648