### PR TITLE
インストーラのメッセージ言語のデフォルトが、前回インストール時の言語ではなく自動になるようにした #636

### DIFF
--- a/installer/teraterm.iss
+++ b/installer/teraterm.iss
@@ -55,6 +55,7 @@ AppSupportURL=https://github.com/TeraTermProject/teraterm/issues
 PrivilegesRequired=none
 ; during installer execution
 ShowLanguageDialog=yes
+UsePreviousLanguage=no
 LicenseFile={#SrcDir}\license.txt
 DefaultDirName={commonpf}\teraterm5
 AllowNoIcons=true


### PR DESCRIPTION
この変更で、このようになる

- 前回、デフォルト言語（OSの言語）から変更していた場合 次のインストールでOSの言語になる（再度選び直す必要がある）
- 前回はOSの言語がサポートされておらず、英語でインストールした場合 新しいインストーラ―で新しくOSの言語が含まれるようになった場合、OSの言語がデフォルトになる