### PR TITLE
Tera Term マクロの restoresetup で INIファイルを相対パスで指定した場合に、%APPDATA%\teraterm5 からの相対パスにならない #706

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -135,6 +135,10 @@
         Fixed Tera Term may stop working when Tera Term macro is executed in hidden mode and Tera Term is executed by <a href="../macro/command/connect.html">connect</a> macro command.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/607" target="_blank">issue #607</a>)
       </li>
+      <li>
+        MACRO: The issue where the INI file specified with a relative path in the <a href="../macro/command/restoresetup.html">restoresetup</a> command was not recognized as a relative path from %APPDATA%\teraterm5\ has been fixed.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/706" target="_blank">issue #706</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -136,6 +136,11 @@
         (<a href="https://github.com/TeraTermProject/teraterm/issues/607" target="_blank">issue #607</a>)
       </li>
       <li>
+        The command line option <a href="../commandline/teraterm.html#f">/F=</a> of the Tera Term has been modified to be reflected in the plugin.<br>
+        In addition, modified it so that the <a href="../commandline/teraterm.html#f">/F=</a> option is carried over to the duplicated session created by [File] - [Duplicate Session].
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/692" target="_blank">issue #692</a>)
+      </li>
+      <li>
         MACRO: The issue where the INI file specified with a relative path in the <a href="../macro/command/restoresetup.html">restoresetup</a> command was not recognized as a relative path from %APPDATA%\teraterm5\ has been fixed.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/706" target="_blank">issue #706</a>)
       </li>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -135,6 +135,10 @@
         Tera Termマクロを非表示で実行して、<a href="../macro/command/connect.html">connect</a>マクロコマンドでTera Termを起動すると動作が停止する場合があったので修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/607" target="_blank">issue #607</a>)
       </li>
+      <li>
+        MACRO: <a href="../macro/command/restoresetup.html">restoresetup</a>コマンドで INI ファイルが相対パスで指定された場合に、%APPDATA%\teraterm5\ からの相対パスと見なされない不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/706" target="_blank">issue #706</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -136,6 +136,11 @@
         (<a href="https://github.com/TeraTermProject/teraterm/issues/607" target="_blank">issue #607</a>)
       </li>
       <li>
+        Tera Term のコマンドラインオプション <a href="../commandline/teraterm.html#f">/F=</a> がプラグインに反映されるように修正した。<br>
+        加えて、[ファイル] → [セッションの複製]で複製されたセッションに <a href="../commandline/teraterm.html#f">/F=</a> オプションが引き継がれるよう修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/692" target="_blank">issue #692</a>)
+      </li>
+      <li>
         MACRO: <a href="../macro/command/restoresetup.html">restoresetup</a>コマンドで INI ファイルが相対パスで指定された場合に、%APPDATA%\teraterm5\ からの相対パスと見なされない不具合を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/706" target="_blank">issue #706</a>)
       </li>

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -786,8 +786,10 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 	}
 	case CmdRestoreSetup: {
 		wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
+		wchar_t *fnameW = GetFullPathW(ts.HomeDirW, ParamFileNameW);
+		free(ParamFileNameW);
 		free(ts.SetupFNameW);
-		ts.SetupFNameW = ParamFileNameW;
+		ts.SetupFNameW = fnameW;
 		WideCharToACP_t(ts.SetupFNameW, ts.SetupFName, _countof(ts.SetupFName));
 		PostMessage(HVTWin,WM_USER_ACCELCOMMAND,IdCmdRestoreSetup,0);
 		break;


### PR DESCRIPTION
#706 の修正パッチをお送りいたします。