### PR TITLE
Setup - Keyboard で設定ダイアログを開いた際、Meta key の値が常に off になる不具合を修正した #624

### DIFF
--- a/teraterm/teraterm/keyboard_pp.c
+++ b/teraterm/teraterm/keyboard_pp.c
@@ -83,19 +83,19 @@ static INT_PTR CALLBACK proc(HWND Dialog, UINT Message, WPARAM wParam, LPARAM lP
 
 			if (!IsWindowsNTKernel()) {
 				static const I18nTextInfo infos[] = {
-					{ "DLG_KEYB_META_OFF", L"off" },
-					{ "DLG_KEYB_META_ON", L"on" }
+					{ "DLG_KEYB_META_OFF", L"off", IdMetaOff },
+					{ "DLG_KEYB_META_ON", L"on", IdMetaOn }
 				};
-				SetI18nListW("Tera Term", Dialog, IDC_KEYBMETA, infos, _countof(infos), ts->UILanguageFileW, 0);
+				SetI18nListW("Tera Term", Dialog, IDC_KEYBMETA, infos, _countof(infos), ts->UILanguageFileW, ts->MetaKey);
 			}
 			else {
 				static const I18nTextInfo infos[] = {
-					{ "DLG_KEYB_META_OFF", L"off" },
-					{ "DLG_KEYB_META_ON", L"on" },
-					{ "DLG_KEYB_META_LEFT", L"left" },
-					{ "DLG_KEYB_META_RIGHT", L"right" }
+					{ "DLG_KEYB_META_OFF", L"off", IdMetaOff },
+					{ "DLG_KEYB_META_ON", L"on", IdMetaOn },
+					{ "DLG_KEYB_META_LEFT", L"left", IdMetaLeft },
+					{ "DLG_KEYB_META_RIGHT", L"right", IdMetaRight }
 				};
-				SetI18nListW("Tera Term", Dialog, IDC_KEYBMETA, infos, _countof(infos), ts->UILanguageFileW, 0);
+				SetI18nListW("Tera Term", Dialog, IDC_KEYBMETA, infos, _countof(infos), ts->UILanguageFileW, ts->MetaKey);
 			}
 
 			SetDropDownList(Dialog, IDC_KEYBKEYB, RussList2, ts->RussKeyb);


### PR DESCRIPTION
Setup - Keyboard で設定ダイアログを開いた際、Meta key の値が常に off になる不具合を修正した #624

#624 3464f65 keyboard_pp.c の修正誤り(デグレ)を修正