### PR TITLE
構造体を事前に宣言するようにした

### DIFF
--- a/ttssh2/ttxssh/digest.h
+++ b/ttssh2/ttxssh/digest.h
@@ -45,6 +45,7 @@ typedef enum {
 	SSH_DIGEST_MAX,
 } digest_algorithm;
 
+struct ssh_digest_ctx;
 
 char* get_digest_algorithm_name(digest_algorithm id);
 

--- a/ttssh2/ttxssh/mac.h
+++ b/ttssh2/ttxssh/mac.h
@@ -57,6 +57,8 @@ typedef enum {
 	HMAC_MAX = HMAC_UNKNOWN,
 } mac_algorithm;
 
+struct Mac;
+
 char* get_ssh2_mac_name(const struct ssh2_mac_t *mac);
 char* get_ssh2_mac_name_by_id(mac_algorithm id);
 // const EVP_MD* get_ssh2_mac_EVP_MD(const struct SSH2Mac *mac);


### PR DESCRIPTION
- 不完全構造体, 内部構造の隠蔽化のため使用
- 次のようなエラーや警告を回避
  - warning: declaration of 'struct Mac' will not be visible outside of this function
  - warning: 'struct Mac' declared inside parameter list will not be visible outside of this definition or declaration
  - error: conflicting types for 'mac_init'; have 'int(struct Mac *)'
- Visual Studio 2022 17.14.9 ではエラーは出ないが、gcc,clangでもビルドできるよう修正