### PR TITLE
MACRO: restoresetup コマンドで相対パスで指定された INI ファイルが %APPDATA%\teraterm5\ から…

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -91,6 +91,8 @@
         The command line option <a href="../commandline/teraterm.html#f">/F=</a> of the Tera Term has been modified to be reflected in the plugin.<br>
         In addition, modified it so that the <a href="../commandline/teraterm.html#f">/F=</a> option is carried over to the duplicated session created by [File] - [Duplicate Session].
         (<a href="https://github.com/TeraTermProject/teraterm/issues/692" target="_blank">issue #692</a>)
+        MACRO: The issue where the INI file specified with a relative path in the <a href="../macro/command/restoresetup.html">restoresetup</a> command was not recognized as a relative path from %APPDATA%\teraterm5\ has been fixed.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/706" target="_blank">issue #706</a>)
       </li>
     </ul>
   </li>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -91,6 +91,8 @@
         Tera Term のコマンドラインオプション <a href="../commandline/teraterm.html#f">/F=</a> がプラグインに反映されるように修正した。<br>
         加えて、[ファイル] → [セッションの複製]で複製されたセッションに <a href="../commandline/teraterm.html#f">/F=</a> オプションが引き継がれるよう修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/692" target="_blank">issue #692</a>)
+        MACRO: <a href="../macro/command/restoresetup.html">restoresetup</a>コマンドで INI ファイルが相対パスで指定された場合に、%APPDATA%\teraterm5\ からの相対パスと見なされない不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/706" target="_blank">issue #706</a>)
       </li>
     </ul>
   </li>

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -786,8 +786,10 @@ static HDDEDATA AcceptExecute(HSZ TopicHSz, HDDEDATA Data)
 	}
 	case CmdRestoreSetup: {
 		wchar_t *ParamFileNameW = ToWcharU8(ParamFileName);
+		wchar_t *fnameW = GetFullPathW(ts.HomeDirW, ParamFileNameW);
+		free(ParamFileNameW);
 		free(ts.SetupFNameW);
-		ts.SetupFNameW = ParamFileNameW;
+		ts.SetupFNameW = fnameW;
 		WideCharToACP_t(ts.SetupFNameW, ts.SetupFName, _countof(ts.SetupFName));
 		PostMessage(HVTWin,WM_USER_ACCELCOMMAND,IdCmdRestoreSetup,0);
 		break;


### PR DESCRIPTION
MACRO: restoresetup コマンドで相対パスで指定された INI ファイルが %APPDATA%\teraterm5\ からの相対パスとして認識されない不具合を修正した #706