### PR TITLE
端末特性報告のドキュメント修正 #623

### DIFF
--- a/doc/en/html/about/ctrlseq.html
+++ b/doc/en/html/about/ctrlseq.html
@@ -174,11 +174,11 @@
 <pre id="TerminalID">
 <i>Ps</i> = 0    Asks for the terminal's architectural class and basic attributes.
 Response: Depends the <a href="../menu/setup-additional-terminal.html#TerminalID">Terminal ID</a> setting. (same as <a href="#ESC_Z">ESC Z</a>.)
-  VT100     CSI ? 1 ; 2 c
-  VT100J    CSI ? 5 ; 2 c
-  VT101     CSI ? 1 ; 0 c
-  VT102     CSI ? 6 c
-  VT102J    CSI ? 15 c
+  VT100     ESC [ ? 1 ; 2 c
+  VT100J    ESC [ ? 5 ; 2 c
+  VT101     ESC [ ? 1 ; 0 c
+  VT102     ESC [ ? 6 c
+  VT102J    ESC [ ? 15 c
   VT220     CSI ? 60 ; 1 ; 2 ; 6 ; 8 ; 9 ; 15 ; c
   VT220J    CSI ? 62 ; 1 ; 2 ; 5 ; 6 ; 7 ; 8 c
   VT282     CSI ? 62 ; 1 ; 2 ; 4 ; 5 ; 6 ; 7 ; 8 ; 10 ; 11 c
@@ -187,6 +187,8 @@ Response: Depends the <a href="../menu/setup-additional-terminal.html#TerminalID
   VT420     CSI ? 64 ; 1 ; 2 ; 7 ; 8 ; 9 ; 15 ; 18 ; 21 c
   VT520     CSI ? 65 ; 1 ; 2 ; 7 ; 8 ; 9 ; 12 ; 18 ; 19 ; 21 ; 23 ; 24 ; 42 ; 44 ; 45 ; 46 c
   VT525     CSI ? 65 ; 1 ; 2 ; 7 ; 9 ; 12 ; 18 ; 19 ; 21 ; 22 ; 23 ; 24 ; 42 ; 44 ; 45 ; 46 c
+
+Note The VT100 series has only 7-bit mode. Therefore, explicitly use "ESC [" instead of CSI.
 </pre>
 </td></tr>
 <tr><td>CSI <i>Ps</i> d</td>	<td>VPA</td>	<td> Move to the corresponding vertical position (line <i>Ps</i>) of the current column. The default value of <i>Ps</i> is 1. </tr>

--- a/doc/ja/html/about/ctrlseq.html
+++ b/doc/ja/html/about/ctrlseq.html
@@ -167,11 +167,11 @@
 <pre id="TerminalID">
 <i>Ps</i> = 0    端末特性を要求する。
 応答: <a href="../menu/setup-additional-terminal.html#TerminalID">端末ID</a>の設定による(<a href="#ESC_Z">ESC Z</a>と同じ)。
-  VT100     CSI ? 1 ; 2 c
-  VT100J    CSI ? 5 ; 2 c
-  VT101     CSI ? 1 ; 0 c
-  VT102     CSI ? 6 c
-  VT102J    CSI ? 15 c
+  VT100     ESC [ ? 1 ; 2 c
+  VT100J    ESC [ ? 5 ; 2 c
+  VT101     ESC [ ? 1 ; 0 c
+  VT102     ESC [ ? 6 c
+  VT102J    ESC [ ? 15 c
   VT220     CSI ? 60 ; 1 ; 2 ; 6 ; 8 ; 9 ; 15 ; c
   VT220J    CSI ? 62 ; 1 ; 2 ; 5 ; 6 ; 7 ; 8 c
   VT282     CSI ? 62 ; 1 ; 2 ; 4 ; 5 ; 6 ; 7 ; 8 ; 10 ; 11 c
@@ -180,6 +180,8 @@
   VT420     CSI ? 64 ; 1 ; 2 ; 7 ; 8 ; 9 ; 15 ; 18 ; 21 c
   VT520     CSI ? 65 ; 1 ; 2 ; 7 ; 8 ; 9 ; 12 ; 18 ; 19 ; 21 ; 23 ; 24 ; 42 ; 44 ; 45 ; 46 c
   VT525     CSI ? 65 ; 1 ; 2 ; 7 ; 9 ; 12 ; 18 ; 19 ; 21 ; 22 ; 23 ; 24 ; 42 ; 44 ; 45 ; 46 c
+
+注 VT100系統は7bitモードのみなので、CSI のかわりに"ESC ["と表記しています
 </pre>
 </td></tr>
 <tr><td>CSI <i>Ps</i> d</td>	<td>VPA</td>	<td>カーソルを桁位置を変えずに <i>Ps</i> 行目に移動する。<i>Ps</i> の省略時の値は 1。</tr>


### PR DESCRIPTION
- VT100系統は、"CSI" の代わりに "ESC [" と表記
- VT100系統には 8bitモードがないことを注記