### PR TITLE
There are cases where the send(ln)broadcast and send(ln)multicast macro commands lose transmitted data (related to #437). #774

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -105,6 +105,10 @@
         The issue where some windows were not displayed in the foreground after right-clicking in the <a href="../menu/control-broadcast.html">Broadcast command</a> dialog's window list and selecting "Bring selected window to foreground" has been fixed.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/736" target="_blank">issue #736</a>)
       </li>
+      <li>
+        MACRO: Fixed the issue where the <a href="../macro/command/sendbroadcast.html">send(ln)broadcast</a> and <a href="../macro/command/sendmulticast.html">send(ln)multicast</a> commands could lose sent data.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/774" target="_blank">issue #774</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -105,6 +105,10 @@
         <a href="../menu/control-broadcast.html">Broadcast command</a>ダイアログのウィンドウリストで右クリック後、Bring selected window to foreground を選択した際、一部のウィンドウがフォアグラウンドで表示されない不具合を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/736" target="_blank">issue #736</a>)
       </li>
+      <li>
+        MACRO: <a href="../macro/command/sendbroadcast.html">send(ln)broadcast</a>、<a href="../macro/command/sendmulticast.html">send(ln)multicast</a>コマンドが送信データをロストする場合がある不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/774" target="_blank">issue #774</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/teraterm/keyboard.c
+++ b/teraterm/teraterm/keyboard.c
@@ -1552,7 +1552,7 @@ void KeyCodeSend(WORD KCode, WORD Count)
 
 	if (CodeLength == 0)
 		return;
-	if (TalkStatus == IdTalkKeyb) {
+	if (TalkStatus == IdTalkKeyb || TalkStatus == IdTalkSendMem) {
 		switch (CodeType) {
 			case IdBinary:
 				SendBinary(Code, CodeLength, Count);

--- a/teraterm/teraterm/ttdde.c
+++ b/teraterm/teraterm/ttdde.c
@@ -459,7 +459,7 @@ static HDDEDATA AcceptPoke(HSZ ItemHSz, UINT ClipFmt,
 	// コマンドの貼り付けを行っていない場合、TalkStatusは IdTalkCB になので、DDE_FNOTPROCESSEDを
 	// 返すことがある。DDE_FBUSYに変更。
 	// (2006.11.6 yutaka)
-	if (TalkStatus != IdTalkKeyb)
+	if (TalkStatus != IdTalkKeyb  && TalkStatus != IdTalkSendMem)
 		return (HDDEDATA)DDE_FBUSY;
 
 	if (ConvH==0) return DDE_FNOTPROCESSED;

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -4846,7 +4846,7 @@ LRESULT CVTWindow::OnReceiveIpcMessage(WPARAM wParam, LPARAM lParam)
 	}
 
 	// 送信可能な状態でなければエラー
-	if (TalkStatus != IdTalkKeyb) {
+	if (TalkStatus != IdTalkKeyb && TalkStatus != IdTalkSendMem) {
 		return 0;
 	}
 


### PR DESCRIPTION
修正案をお送りさせて頂きます。