### PR TITLE
Fix some typos

### DIFF
--- a/doc/en/html/about/emulations.html
+++ b/doc/en/html/about/emulations.html
@@ -31,7 +31,7 @@ About text and background colors.
 
 <h2>Available color modes</h2>
 
-Following checkboxes can be setted in Settings - Window Settings.
+Following checkboxes can be set in Settings - Window Settings.
 
 Each mode can be used simultaneously.
 

--- a/doc/en/html/about/emulations_dec_special.html
+++ b/doc/en/html/about/emulations_dec_special.html
@@ -23,7 +23,7 @@ SO(0x0e) can be used to display DEC Special Graphics.
 </p>
 
 <p>
-Tera Term can display DEC Special Graphics using its Special font(font name is "TSPECIAL1.TTF", font name is "Tera Specail").<br>
+Tera Term can display DEC Special Graphics using its Special font(font file is "TSPECIAL1.TTF", font name is "Tera Special").<br>
 All Tera Special character widths are 1cell.
 </p>
 
@@ -58,7 +58,7 @@ echo -e "_abcdefghijklmnopqrstuvwxyz\x7b\x7c\x7e\r\n\x0e_abcdefghijklmnopqrstuvw
 </p>
 
 <p>
-  See also informations on web.
+  See also information on web.
   <ul>
     <li>Digital Equipment Corporation. <a href="https://vt100.net/docs/vt100-ug/chapter3.html#T3-9" target="_blank">Table 3-9 Special Graphics Characters</a>. VT100 User Guide.</li>
     <li>Digital Equipment Corporation. <a href="https://vt100.net/docs/vt220-rm/table2-4.html" target="_blank">Table 2-4 DEC Special Graphics Character Set</a>. VT220 Programmer Reference.</li>

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -492,7 +492,7 @@
       <li>MACRO: fixed <a href="../macro/command/sendfile.html">sendfile</a> command stuck even if transmission is completed to send.</li>
       <li>MACRO: <a href="../macro/command/settitle.html">settitle</a> command using Kanji characters will be crashed.
         <ul>
-          <li>Fixed <a href="../macro/command/settitle.html">settitle</a>, <a href="../macro/command/gettitle.html">gettitle</a>, <a href="../macro/command/loadkeymap.html">loadkeymap</a> to handel string in Unicode.
+          <li>Fixed <a href="../macro/command/settitle.html">settitle</a>, <a href="../macro/command/gettitle.html">gettitle</a>, <a href="../macro/command/loadkeymap.html">loadkeymap</a> to handle string in Unicode.
           <li>Currently, Tera Term handle local title strings in ANSI strings. Characters that cannot be converted are replaced by "?".</li>
         </ul>
       </li>
@@ -520,9 +520,9 @@
         </ul></li>
       <li>Added setting Underline attribute(SGR 4) color and font</li>
       <li>if log file name from command line or default log file name is not full path, now it is considered as relative path from <a href="../setup/folder.html#LogDir">log folder</a> or <a href="../menu/setup-additional-log.html#LogDefaultPath">default log save folder</a>.</li>
-      <li>Exchanged foreground and background colors of characters that attributes is setted ANSIColor when colors are reversed with DECSCNM set.</li>
+      <li>Exchanged foreground and background colors of characters that attributes is set ANSIColor when colors are reversed with DECSCNM set.</li>
       <li>U+00A0(NBSP) and U+2000..U+2003 are converted to SPACE and displayed. tree command output is displayed correctly.</li>
-      <li>XMODEM: Fix to check all received datas and process correctly, even if received datas are accumulated.</li>
+      <li>XMODEM: Fix to check all received data and process correctly, even if received data are accumulated.</li>
       <li>YMODEM: ignore continuous 'C' when waiting for sending.</li>
       <li>Changed window position to specified in TERATERM.INI when duplicate a session.</li>
       <li>added a setting that can disable corner rounding of VT Window and TEK Window in Windows 11.
@@ -2525,7 +2525,7 @@
     <ul>
       <li>disabled the Plain text and Timestamp flag when the Binary flag is enabled.</li>
       <li>added the display method of <a href="../menu/setup-additional.html">Accept Window Title Change Request</a>. The title can insert before or after the canonical title.</li>
-      <li>moved the "Delimitter Characters" configuration from "General" tab to "Copy and Paste" tab on the <a href="../menu/setup-additional.html">"Additional settings" dialog</a>.</li>
+      <li>moved the "Delimiter Characters" configuration from "General" tab to "Copy and Paste" tab on the <a href="../menu/setup-additional.html">"Additional settings" dialog</a>.</li>
       <li>added the <a href="../commandline/teraterm.html">/DS</a> command line option. It disables the "New connection" dialog.</li>
       <li>Preserved the comment and the position of the entry in teraterm.ini file when a user saved the Tera Term configuration.</li>
       <li>added support for replace the command of UK character set with the US-ASCII. This is the workaround that the lower-case alphabet can not properly display after showing DEC special character.</li>
@@ -3381,7 +3381,7 @@ SYNOPSIS:
       <li>added saving log type(plain text) information to teraterm.ini(LogTypePlainText).</li>
       <li>added CygTerm settings on Additional settings dialog.</li>
       <li>added CygTerm settings on Additional settings dialog.</li>
-      <li>added support of selecting several pages(also expansion ans contraction of text area that has been selected). Start selected region is saved with mouse left click. End selected region is saved with Shift + mouse left click.</li>
+      <li>added support of selecting several pages(also expansion and contraction of text area that has been selected). Start selected region is saved with mouse left click. End selected region is saved with Shift + mouse left click.</li>
       <li>added scroll out the current buffer when TeraTerm clear screen at receiving &lt;ESC&gt;[J.</li>
       <li>added the workaround of CPU time 100% using TeraTerm macro(insert 100msec sleep after send and sendln). </li>
 </ul>
@@ -3912,7 +3912,7 @@ SYNOPSIS:
     <ul>
       <li>Added support for multiple required authentication.
         <ul>
-          <li>Auto login, connect from macro and duplicate session are not supported, because TTSSH cannot receive multiple authentication informations from command line parameters.</li>
+          <li>Auto login, connect from macro and duplicate session are not supported, because TTSSH cannot receive multiple authentication information from command line parameters.</li>
         </ul>
       </li>
       <li>If option(<a href="../commandline/ttssh.html#f">/f</a>, <a href="../commandline/ttssh.html#ssh-f">/ssh-f</a>, <a href="../commandline/ttssh.html#ssh-consume">/ssh-consume</a>, <a href="../commandline/ttssh.html#keyfile">/keyfile</a>) argument file name is not absolute path, modify it to be treated as a relative path from %APPDATA%\teraterm5\.</li>
@@ -5875,7 +5875,7 @@ SYNOPSIS:
 <ul class="history">
       <li>Added LockBox to encrypt and save passwords.</li>
       <li>In the Details dialog, the "use SSH" checkbox no longer turns on when the executable file name includes "ttermpro.exe".</li>
-      <li>Fixed a typo in the title of the List Configuration dialog. (Cofiguration -> Configuration)</li>
+      <li>Fixed a typo in the title of the List Configuration dialog. (Configuration -> Configuration)</li>
       <li>Added the risk of information leaks to <a href="../usage/TTMenu/TTMenu.html">document</a>.</li>
 </ul>
 

--- a/doc/en/html/about/qanda.html
+++ b/doc/en/html/about/qanda.html
@@ -51,7 +51,7 @@ No problem. Need not announce to us. Tera Term has been distributed under the <a
 <p>
 <span class="qanda">Q.</span> EAR (Export Administration Regulations)<br>
 <span class="qanda">A.</span>
-Tera Term includes modules made in the USA. As such, it may be subject to U.S. export control laws known as ECCN-5D002, cryptograhic software. Downloading it outside of Japan will be considered as re-export because the laws applies to re-exports.<br>
+Tera Term includes modules made in the USA. As such, it may be subject to U.S. export control laws known as ECCN-5D002, cryptographic software. Downloading it outside of Japan will be considered as re-export because the laws applies to re-exports.<br>
 Tera Term distributed on TeraTerm Project has been already finished the following.
 <ul>
     <li>A user is able to get the software without restrictions.</li>
@@ -75,7 +75,7 @@ For more information, see the project wiki page "<a href="https://github.com/Ter
 </ul>
 
 <p>
-Please read message and confirm followings:
+Please read message and confirm following:
 </p>
 
 <dl>
@@ -280,7 +280,7 @@ Tera Term 4 using the ANSI(not Unicode) API can also read/write
 Unicode ini files because the OS converts the character encoding.
 
 But, if the characters cannot be converted in ANSI/Unicode,
-characters will be breaked.
+characters will be broken.
 
 And, Windows 9x does not have a character code conversion function in API,
 Unicode version ini files cannot be used.

--- a/doc/en/html/commandline/ttproxy.html
+++ b/doc/en/html/commandline/ttproxy.html
@@ -24,7 +24,7 @@ protocol://&lt;user&lt;:password&gt;@&gt;proxyserver:proxyport/realhost
 
 <dl>
   <dt id="protocol">protocol</dt>
-  <dd>Proxy type<br>Supported proxy types are followings:
+  <dd>Proxy type<br>Supported proxy types are following:
     <ul>
       <li>http</li>
       <li>telnet</li>

--- a/doc/en/html/macro/appendixes/negative.html
+++ b/doc/en/html/macro/appendixes/negative.html
@@ -26,7 +26,7 @@ causes the syntax error, because the second parameter is regarded as "5-1" inste
 <pre><code>for i 5 0-1</code></pre>
   </li>
 
-  <li>Add parenthese.
+  <li>Add parentheses.
 <pre><code>for i 5 (-1)</code></pre>
   </li>
 

--- a/doc/en/html/macro/command/fileopen.html
+++ b/doc/en/html/macro/command/fileopen.html
@@ -27,7 +27,7 @@ fileopen &lt;file handle&gt; &lt;filename&gt; &lt;append flag&gt; [&lt;readonly 
 	<dt class="macro">integer variable &lt;file handle&gt;</dt>
 	<dd>If the file is successfully opened, the file handle is returned in this variable.<br />
         version 4.101 or earlier, and 4.104 or later: Otherwise, &lt;file handle&gt; is set to -1. The macro error does not cause.<br />
-        version 4.102 and 4.103: Otherwise, &lt;file handle&gt; is set to -1. The macro script is halted after the macro eror causes.</dd>
+        version 4.102 and 4.103: Otherwise, &lt;file handle&gt; is set to -1. The macro script is halted after the macro error causes.</dd>
 
 	<dt class="macro">string &lt;filename&gt;</dt>
 	<dd>Specify an opened file name<br />

--- a/doc/en/html/macro/command/fileseek.html
+++ b/doc/en/html/macro/command/fileseek.html
@@ -25,7 +25,7 @@ fileseek &lt;file handle&gt; &lt;offset&gt; &lt;origin&gt;
 
 <p>
 Moves the pointer for the file specified by &lt;file handle&gt;.<br>
-With this command, the file pointer is moved to followings:
+With this command, the file pointer is moved to following:
 </p>
 
 <table>

--- a/doc/en/html/macro/command/filestrseek.html
+++ b/doc/en/html/macro/command/filestrseek.html
@@ -14,7 +14,7 @@
 <h1>filestrseek</h1>
 
 <p>
-Forward searchs a string from a file.
+Forward searches a string from a file.
 </p>
 
 <pre class="macro-syntax">

--- a/doc/en/html/macro/command/send.html
+++ b/doc/en/html/macro/command/send.html
@@ -30,7 +30,7 @@ If &lt;data&gt; is an integer, its lowest-order byte (0-255) is regarded as an A
 </p>
 
 <p>
-  The datas are checked, and when data is judged to be text, data is sent in same as "<a href="sendtext.html">sendtext</a>"; when data is judged to be binary, data is sent in same as "<a href="sendbinary.html">sendbinary</a>".
+  The data are checked, and when data is judged to be text, data is sent in same as "<a href="sendtext.html">sendtext</a>"; when data is judged to be binary, data is sent in same as "<a href="sendbinary.html">sendbinary</a>".
 <p>
 
 <h2>Example</h2>

--- a/doc/en/html/macro/command/sendbinary.html
+++ b/doc/en/html/macro/command/sendbinary.html
@@ -14,7 +14,7 @@
 <h1>sendbinary</h1>
 
 <p>
-Sends binary data. <em>(version 5.3 or lator)</em>
+Sends binary data. <em>(version 5.3 or later)</em>
 </p>
 
 <pre class="macro-syntax">

--- a/doc/en/html/macro/command/sendtext.html
+++ b/doc/en/html/macro/command/sendtext.html
@@ -14,7 +14,7 @@
 <h1>sendtext</h1>
 
 <p>
-Sends text data. <em>(Version 5.3 or lator)</em>
+Sends text data. <em>(Version 5.3 or later)</em>
 </p>
 
 <pre class="macro-syntax">

--- a/doc/en/html/macro/command/sprintf2.html
+++ b/doc/en/html/macro/command/sprintf2.html
@@ -80,7 +80,7 @@ As a result of this command, the system variable "result" is set to one of the f
 </tr>
 <tr>
   <td>4</td>
-  <td>Invalid destnation variable</td>
+  <td>Invalid destination variable</td>
 </tr>
 </table>
 

--- a/doc/en/html/menu/file-sendfile.html
+++ b/doc/en/html/menu/file-sendfile.html
@@ -144,7 +144,7 @@
 Tera Term ---&gt; Send buffer  ---&gt; Windows ---&gt; (sshd,telnet,pipe) ---&gt; OS,driver      ---&gt; pty + shell, other program
                in Tera Term                   (serial          )      UART chip,ext       Embedded programs, etc.
 
-               receive bufer &lt;--         &lt;---                    &lt;---                &lt;---
+               receive buffer &lt;--         &lt;---                    &lt;---                &lt;---
                      r1            r2                 r3                r4
     </pre>
 

--- a/doc/en/html/menu/file-transfer-kermit-get.html
+++ b/doc/en/html/menu/file-transfer-kermit-get.html
@@ -17,7 +17,7 @@
     <h2>"Kermit Get" dialog box</h2>
     <p>
       Enter the file name to be received.<br>
-      The received file is stored in the <a href="../setup/folder.html#FileDir">File transfer foler</a>.
+      The received file is stored in the <a href="../setup/folder.html#FileDir">File transfer folder</a>.
     </p>
   </body>
 </html>

--- a/doc/en/html/menu/file-transfer-xmodem-recv.html
+++ b/doc/en/html/menu/file-transfer-xmodem-recv.html
@@ -34,7 +34,7 @@
       <dd>
         <ul>
           <li>
-            Checkd: Received data is treated as binary and saved in a file without modification.<br>
+            Checked: Received data is treated as binary and saved in a file without modification.<br>
             The last received packet is packed with padding(EOF,$1A).
             For this reason, the end of file cannot be known when the end of the sent file is $1A.
           </li>
@@ -46,7 +46,7 @@
                 A single CR($0D) or LF($0A) is converted to CR+LF($0D+$0A).
               </li>
               <li>
-                Remove padding(EOF,$0A) of each reciving packet<br>
+                Remove padding(EOF,$0A) of each receiving packet<br>
                 EOF($1A) does not appear in the text. So $1A at the end of the file will be removed.
               </li>
             </ul>

--- a/doc/en/html/menu/setup-additional-coding.html
+++ b/doc/en/html/menu/setup-additional-coding.html
@@ -34,7 +34,7 @@
     Specify character width assumed by Tera Term connecting destination.<br>
     Refer to <a href="#EastAsianWidth">East_Asian_Width and width (cells)</a>.<br>
     Refer to <a href="setup-additional-font.html#ResizedFont">Drawing resized font to fit cell width</a> for Tera Term drawing character width.
-    If you change Encoding-receive by pull-down, width is changed to typical characte witdh of that code automatically. Nevertheless, that width is not absolutely recommend, you can choose the width what you want for font or other reasons.
+    If you change Encoding-receive by pull-down, width is changed to typical character width of that code automatically. Nevertheless, that width is not absolutely recommend, you can choose the width what you want for font or other reasons.
 
     <h3 id="UnicodeEmojiOverride">Override Emoji Characters width</h3>
 
@@ -56,7 +56,7 @@
     Select display method for <a href="../about/emulations_dec_special.html">DEC Special Graphics</a>
 
     <dl>
-      <dt>Mapping Unicode to DEC Special Grahpics</dt>
+      <dt>Mapping Unicode to DEC Special Graphics</dt>
       <dd>
         Unicode is converted to DEC Special Graphic, displays with "Tera Special" font.<br>
         Character width of DEC Special Graphic is 1 cell (half-width).<br>
@@ -68,7 +68,7 @@
           <dt>Middle dots(U+00B7,U+2024,U+2219)</dt>
         </dl>
       </dd>
-      <dt>Mapping DEC Special Grahpics to Unicode</dt>
+      <dt>Mapping DEC Special Graphics to Unicode</dt>
       <dd>
         DEC Special Graphic is converted to Unicode, displays with VT Window font.
         The character width displayed in Unicode differs for each character.

--- a/doc/en/html/menu/setup-additional-terminal.html
+++ b/doc/en/html/menu/setup-additional-terminal.html
@@ -73,7 +73,7 @@
 	<p>
 	Note that the terminal ID is not identical to the telnet terminal type.<br>
 	To change the telnet terminal type, use the
-	<a href="setup-additional-tcpip.html#TermType">Terminal type in [Setup] Addtional Setting "TCP/IP" tab</a>.
+	<a href="setup-additional-tcpip.html#TermType">Terminal type in [Setup] Additional Setting "TCP/IP" tab</a>.
       </dd>
 
       <dt id="LocalEcho">Local echo</dt>

--- a/doc/en/html/menu/setup-additional-visual-theme.html
+++ b/doc/en/html/menu/setup-additional-visual-theme.html
@@ -19,9 +19,9 @@
 
     <dl>
       <dt><a href="#preview">Preview/File tab</a></dt>
-      <dd>Temporary theme settings(preview), loading and saveing theme files.</dd>
+      <dd>Temporary theme settings(preview), loading and saving theme files.</dd>
       <dt><a href="#bg">Background tab</a></dt>
-      <dd>BG(Backgroud) related settings.</dd>
+      <dd>BG(Background) related settings.</dd>
       <dt><a href="#bg_alpha">Background image alpha tab</a></dt>
       <dd>Transparency of the background image and text background color.</dd>
       <dt><a href="#color">Text color tab</a></dt>

--- a/doc/en/html/reference/build_library_with_cmake.md
+++ b/doc/en/html/reference/build_library_with_cmake.md
@@ -82,11 +82,11 @@ Using cmake in each environment.
 
 - Downloaded archives are stored.
 - Downloading automatically.
-- Re-use these archives downloaded already.
+- Reuse these archives downloaded already.
 - Can be removed if these archives do not need after building.
 
 ## Build directory
 
 - Building under `build/oniguruma/{compiler}/`.
-- Remove it in advance if rebuliding.
+- Remove it in advance if rebuilding.
 - Can be removed if this do not need after building.

--- a/doc/en/html/reference/build_with_cmake.md
+++ b/doc/en/html/reference/build_with_cmake.md
@@ -1,7 +1,7 @@
 ﻿# How to build by using cmake
 
 - You can build Tera Term by using [cmake](<https://cmake.org/>)(EXPERIMENTAL).
-- You can bulid using Visual Studio, NMake, MinGW
+- You can build using Visual Studio, NMake, MinGW
 
 ## cmake version
 
@@ -36,7 +36,7 @@ To build installer
 
 ### NMake (Visual Studio, very experimental)
 
-Execute vcvars32.bat,etc to prepare an environment where nmake, cl are avaiable,
+Execute vcvars32.bat,etc to prepare an environment where nmake, cl are available,
 Run next commands.
 
     mkdir build_nmake

--- a/doc/en/html/reference/develop-build.html
+++ b/doc/en/html/reference/develop-build.html
@@ -22,7 +22,7 @@
   <li><a href="#build-detail">How to build (Detail)</a>
     <ol>
       <li><a href="#build-checkout">Clone source code</a></li>
-      <li><a href="#build-library">Build libaries</a></li>
+      <li><a href="#build-library">Build libraries</a></li>
       <li><a href="#build-teraterm">Build Tera Term</a></li>
       <li><a href="#build-ttssh">Build TTSSH</a></li>
       <li><a href="#build-ttproxy">Build TTProxy</a></li>
@@ -97,7 +97,7 @@ Run installer\release.bat, and select 3.
 Clone source code from GitHub (https://github.com/TeraTermProject/teraterm).
 </p>
 
-<h3 id="build-library">Build libaries</h3>
+<h3 id="build-library">Build libraries</h3>
 
 <p>
 Launch "x86 Native Tools Command Prompt for VS 2022" batch file from start menu, or set appropriate directory to PATH.<br />

--- a/doc/en/html/reference/develop-memo.html
+++ b/doc/en/html/reference/develop-memo.html
@@ -82,7 +82,7 @@ It recommends that the new name like as Baz....
 
 <ul>
   <li>Source code<br>
-      Read langage file</li>
+      Read language file</li>
   <li>If a message is on dialog, put English message as default text</li>
   <li>Modify language file<br>
       Modify files under installer/release/lang_utf8 folder.
@@ -331,7 +331,7 @@ Otherwise, when a program load an icon image without specifying pixel size for g
 <p>
 Icon file include 4-bit images.<br>
 Windows NT 4.0 supports only 4-bit icon. And notification area icon on Windows 2000 supports only 4-bit icon.<br>
-4-bit color palette is followings:
+4-bit color palette is following:
 </p>
 
 <table border="1">
@@ -386,7 +386,7 @@ Windows NT 4.0 supports only 4-bit icon. And notification area icon on Windows 2
 </table>
 
 <p>
-Source file of each icon images are followings:
+Source file of each icon images are following:
 </p>
 
 <table border="1" style="margin-bottom:1ex;">
@@ -569,7 +569,7 @@ Source file of each icon images are followings:
   <li>Under add/manual folder of TeraTermProject/update_website repository
     <ul>
       <li>License files for web site is managed in TeraTermProject/update_website repository.<br>
-          Replace a license file when it is cahnged.</li>
+          Replace a license file when it is changed.</li>
     </ul>
   </li>
 </ul>
@@ -600,7 +600,7 @@ Required Files
   <dt>pdb file</dt>
   <dd>
     pdb = program database files (symbol files)<br>
-    debug infomation file for exe file
+    debug information file for exe file
   </dd>
 
   <dt>exe file</dt>

--- a/doc/en/html/reference/image/ssh2_plantuml.txt
+++ b/doc/en/html/reference/image/ssh2_plantuml.txt
@@ -126,7 +126,7 @@ group Key Exhnage
     C -> S: SSH_MSG_KEX_DH_GEX_REQUEST
     note left: min\nn\nmax
 
-    note over S #ffffff: finds group that matchs client request size\n  p ... prime\n  g ... generator
+    note over S #ffffff: finds group that matches client request size\n  p ... prime\n  g ... generator
 
     C <- S: SSH_MSG_KEX_DH_GEX_GROUP
     note right: p\ng
@@ -275,7 +275,7 @@ group Authentication
     note left: user name\n"ssh-connection"\n"none"
 
     C <- S: SSH_MSG_USERAUTH_FAILURE
-    note right: supported autentication methods
+    note right: supported authentication methods
 
   end
 

--- a/doc/en/html/setup/folder.html
+++ b/doc/en/html/setup/folder.html
@@ -91,7 +91,7 @@ Folders and full paths of files can be found in <a href="../menu/setup-directory
   <li>Content of portable.ini file does not matter. (zero size file is accepted)</li>
 </ul>
 
-<h1>folders and files which is used by insaller edition</h1>
+<h1>folders and files which is used by installer edition</h1>
 
 <h2>Example for Windows Vista or later</h2>
 
@@ -185,7 +185,7 @@ Folders and full paths of files can be found in <a href="../menu/setup-directory
 
 <h2>When setup files is not exist</h2>
 
-<p>ttermpro.exe behaves followings:</p>
+<p>ttermpro.exe behaves following:</p>
 
 <ul>
   <li>create a folder to put setup files</li>

--- a/doc/en/html/setup/teraterm-com.html
+++ b/doc/en/html/setup/teraterm-com.html
@@ -210,7 +210,7 @@ TelAutoDetect=on
 
 <p>
 Tera Term now supports for "Line at a time" mode from version 4.63.<br>
-Since the default value of this setting is on, when it is used in TCP/IP connection, input characters are not sent until the line feed is inputed.
+Since the default value of this setting is on, when it is used in TCP/IP connection, input characters are not sent until the line feed is inputted.
 But, this setting is disabled (forced to "Character at a time" mode) when following situations:
 </p>
 

--- a/doc/en/html/setup/teraterm-misc.html
+++ b/doc/en/html/setup/teraterm-misc.html
@@ -393,7 +393,7 @@ SYNOPSIS:
 %d      Day of month as decimal number (01 - 31)
 %e      Day of month as decimal number ( 1 - 31)
 %H      Hour in 24-hour format (00 - 23)
-%N      Milisecond as decimal number (000 - 999)
+%N      Millisecond as decimal number (000 - 999)
 %m      Month as decimal number (01 - 12)
 %M      Minute as decimal number (00 -  59)
 %S      Second as decimal number (00 - 59)

--- a/doc/en/html/setup/teraterm-ssh.html
+++ b/doc/en/html/setup/teraterm-ssh.html
@@ -232,7 +232,7 @@ The environment variable is disable and the  localhost:0.0 is used.
 </p>
 
 <p>
-This configuration is overwitten with <a href="../commandline/ttssh.html#ssh-x">/ssh-X command line option</a>.
+This configuration is overwritten with <a href="../commandline/ttssh.html#ssh-x">/ssh-X command line option</a>.
 The configuration priority is as follows.
 </p>
 

--- a/doc/en/html/setup/teraterm-win.html
+++ b/doc/en/html/setup/teraterm-win.html
@@ -303,7 +303,7 @@ Where:
 Example:
 VTFontSpace=0,1,0,0    expand 1 pixel of right side space for each character.
 VTFontSpace=0,0,1,0    expand 1 pixel of space above each line.
-VTFontSpace=0,0,-1,-1  reduce 1 pixel of space above and bellow each line.
+VTFontSpace=0,0,-1,-1  reduce 1 pixel of space above and below each line.
 </pre>
 
 <pre>

--- a/doc/en/html/usage/migrate_to_5.html
+++ b/doc/en/html/usage/migrate_to_5.html
@@ -71,7 +71,7 @@
             <li>character encoding of cygterm.cfg is UTF-8 in Cygwin 3.3.4.</li>
           </ul>
         </li>
-        <li>Tera Term 5 suports UTF-16 (with LE BOM) ini file.<br>
+        <li>Tera Term 5 supports UTF-16 (with LE BOM) ini file.<br>
           <ul>
             <li>Win32APIs for ini files are used Unicode version.  cf. <a href="../reference/dev/win32api.html#ini_file">Win32API/ini file</a><br>
                 Tera Term 4 does not use the Unicode version of the API. the item in ini file could not be handled correctly if non ACP characters are included.</li>

--- a/doc/en/html/usage/ssh.html
+++ b/doc/en/html/usage/ssh.html
@@ -60,7 +60,7 @@
       For example, the OpenSSH client will be able to login to the server without regard to the difference the password and the keyboard-interactive authentication. However, the TTSSH can not login to the server which only enabled keyboard-interactive and public key authentication by using the password authentication.
     </p>
     <ul>
-      <li>If you want to use Password authentication, then make sure that [Use plain password to log in] is chcked and type in username and password. If they are correct, you can login.<br>
+      <li>If you want to use Password authentication, then make sure that [Use plain password to log in] is checked and type in username and password. If they are correct, you can login.<br>
           NOTE: The password can not be sent as plain text like TELNET protocol because the SSH packet including the password data is encrypted.</li>
       <li>When using public key authentication, check [RSA/DSA/ECDSA/ED25519 key to log in] (second from the top line) and click [Private key file:] to specify Private key file. Then type in username and Private key pass phrase.<br>
           Note: TTSSH 2.63(Tera Term 4.76) later can support the PuTTY format and SECSH(ssh.com) format of the SSH2 private key.</li>

--- a/doc/en/html/usage/tips/zmodem.html
+++ b/doc/en/html/usage/tips/zmodem.html
@@ -65,7 +65,7 @@ Reference: <A HREF="forwarding-files.html">Transfer the file via the intermediat
 <p>
 The ZMODEM file transfer will work well for the lrzsz package on the Red Hat Linux(e.g., Fedora, CentOS). The transfer may not work well for the zmtx-zmrx package.
 <br>
-When a user uses the com0com software, Tera Term can use loopback test with another Tera Term and Hypter terminal.
+When a user uses the com0com software, Tera Term can use loopback test with another Tera Term and Hyper terminal.
 </p>
 
 <p>Modem communication program

--- a/doc/en/html/usage/transparent.html
+++ b/doc/en/html/usage/transparent.html
@@ -106,7 +106,7 @@ Eterm(<a href="https://github.com/mej/Eterm" target="_blank">GitHub</a>) is a vt
 <ul>
   <li>Windows 11 desktop image</li>
   <li><a href="https://www.artic.edu/artworks/24645/under-the-wave-off-kanagawa-kanagawa-oki-nami-ura-also-known-as-the-great-wave-from-the-series-thirty-six-views-of-mount-fuji-fugaku-sanjurokkei" target="_blank">Fugaku sanjurokkei</a></li>
-  <li><a href="https://github.com/mej/Eterm/blob/master/bg/README.backgrounds" target="_blank">Circut</a></li>
+  <li><a href="https://github.com/mej/Eterm/blob/master/bg/README.backgrounds" target="_blank">Circuit</a></li>
 </ul>
 
 </BODY>


### PR DESCRIPTION
Hello!

This PR fixes some typos in the English documentation. I initially saw a typo in the words "version 5.3 or lator", so I used the "codespell" tool to search for additional typos in the English documentation.

Thanks for your work on Tera Term. I used it for automation for 10 years, and I'm grateful for your work on Tera Term!