### PR TITLE
プロトコルのキャンセル処理の修正 #473

### DIFF
--- a/teraterm/teraterm/filesys_proto.cpp
+++ b/teraterm/teraterm/filesys_proto.cpp
@@ -789,24 +789,6 @@ void ProtoDlgCancel(void)
 
 		// キャンセルが押されたことを通知する
 		fv->ProtoOp->Cancel(fv, &cv);
-
-		// 特別処理
-		// 		通常何もしない
-		switch (fv->ProtoId) {
-		case PROTO_ZM:
-		case PROTO_XM:
-			break;
-		case PROTO_KMT:
-		case PROTO_BP:
-		case PROTO_QV:
-		case PROTO_YM:
-			// ダイアログを閉じる
-			ProtoEnd();
-			break;
-		default:
-			assert(FALSE);
-			break;
-		}
 	}
 }
 

--- a/teraterm/teraterm/filesys_proto.h
+++ b/teraterm/teraterm/filesys_proto.h
@@ -100,12 +100,28 @@ typedef struct FileVarProto {
 typedef TFileVarProto *PFileVarProto;
 
 // プロトコルのオペレーション
+//   各プロトコルの実装
 typedef struct ProtoOp_ {
+	// 初期化処理
+	// メモリ確保、状態初期化等を行う
+	//	@retval	TRUE	正常終了
+	//	@retval	FALSE	異常終了、初期化失敗
 	BOOL (*Init)(struct FileVarProto *fv, PComVar cv, PTTSet ts);
+	// 処理の継続
+	//	@retval	TRUE	正常、処理を継続終了
+	//	@retval	FALSE	終了、引き続きParse()を呼ぶ必要なし
 	BOOL (*Parse)(struct FileVarProto *fv, PComVar cv);
+	// タイムアウト通知
+	//	タイムアウトが発生したことをプロトコル処理に通知
 	void (*TimeOutProc)(struct FileVarProto *fv, PComVar cv);
+	// キャンセル通知
+	//	ユーザーがキャンセルしたことをプロトコル処理に通知
 	void (*Cancel)(struct FileVarProto *fv, PComVar cv);
+	// パラメータ設定
+	//	プロトコルごとのパラメータ設定
 	int (*SetOptV)(struct FileVarProto *fv, int request, va_list ap);
+	// 終了処理
+	//	メモリの開放などを行う
 	void (*Destroy)(struct FileVarProto *fv);
 } TProtoOp;
 

--- a/teraterm/ttpfile/bplus.c
+++ b/teraterm/ttpfile/bplus.c
@@ -853,6 +853,10 @@ static BOOL BPParse(PFileVarProto fv, PComVar cv)
   BYTE b;
   PBPVar bv = fv->data;
 
+  if (bv->BPState==BP_Close) {
+    return FALSE;
+  }
+
   do {
 
     /* Send packet */

--- a/teraterm/ttpfile/kermit.h
+++ b/teraterm/ttpfile/kermit.h
@@ -36,10 +36,13 @@ extern "C" {
 #endif
 
   /* Kermit function id */
-#define IdKmtReceive 1
-#define IdKmtGet     2
-#define IdKmtSend    3
-#define IdKmtFinish  4
+typedef enum {
+	IdKmtQuit    = 0,	// “à•”‚Åg—pAˆ—‚ªŠ®—¹‚µ‚½ó‘Ô
+	IdKmtReceive = 1,
+	IdKmtGet     = 2,
+	IdKmtSend    = 3,
+	IdKmtFinish  = 4,
+} KMT_MODE_T;
 
   /* KERMIT option */
 #define KmtOptLongPacket 1

--- a/teraterm/ttpfile/quickvan.h
+++ b/teraterm/ttpfile/quickvan.h
@@ -37,8 +37,10 @@ extern "C" {
 #endif
 
   /* Quick-VAN function id */
-#define IdQVReceive 1
-#define IdQVSend    2
+typedef enum {
+	IdQVReceive = 1,
+	IdQVSend    = 2,
+} QV_MODE_T;
 
 enum {
 	QUICKVAN_MODE,

--- a/teraterm/ttpfile/ymodem.h
+++ b/teraterm/ttpfile/ymodem.h
@@ -30,15 +30,16 @@
 
 #pragma once
 
-#include "xmodem.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
   /* YMODEM function id */
-#define IdYReceive 1
-#define IdYSend    2
+typedef enum {
+	IdYQuit = 0,	// “à•”‚Åg—pAˆ—‚ªŠ®—¹‚µ‚½ó‘Ô
+	IdYReceive = 1,
+	IdYSend = 2,
+} YMODEM_MODE_T;
 
   /* YMODEM option */
 #define Yopt1K 1


### PR DESCRIPTION
- 各プロトコル処理にキャンセルを通知した後、プロトコルごとの特別処理をなくした
  - filesys_proto.cpp
- プロトコルごとの処理にコメントを追加した
  - filesys_proto.h
- cancel()後、parse()でFALSEが返ってくるよう修正した
  - ymodem
  - kermitの送信、受信
    - 取得,finishは未テスト
  - BPlus, QuickVanはソースを見て修正、未テスト
- ymodem 受信時、キャンセルの受信に未対応と思われる