### PR TITLE
There are cases where the send(ln)broadcast, send(ln)multicast and sendkcode macro commands lose transmitted data (related to #437). #774

### DIFF
--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -4845,11 +4845,6 @@ LRESULT CVTWindow::OnReceiveIpcMessage(WPARAM wParam, LPARAM lParam)
 		SendMemContinuously();	// TODO 必要?
 	}
 
-	// 送信可能な状態でなければエラー
-	if (TalkStatus != IdTalkKeyb && TalkStatus != IdTalkSendMem) {
-		return 0;
-	}
-
 	const COPYDATASTRUCT *cds = (COPYDATASTRUCT *)lParam;
 	BroadCastReceive(cds);
 


### PR DESCRIPTION
送信バッファへのpush時の排他は不要なため、送信可能状態の判定を削除するPRになります。