### PR TITLE
Tera Term終了時不正な処理が発生する場合があるので修正 #801

### DIFF
--- a/teraterm/common/directx.cpp
+++ b/teraterm/common/directx.cpp
@@ -63,8 +63,10 @@ BOOL DXInit(void)
  */
 void DXUninit(void)
 {
-	pDWriteFactory->Release();
-	pDWriteFactory = NULL;
+	if (pDWriteFactory != NULL) {
+		pDWriteFactory->Release();
+		pDWriteFactory = NULL;
+	}
 }
 
 /**


### PR DESCRIPTION
- DirectX が使えない環境の場合発生
  - リリースバイナリはVisual Studio 2022でビルドしているので、Windows7以上で動作
  - Windows7以上ではDirectXが使用可
  - リリースバイナリでは発生しない不具合のはず
- DirectX の初期化を行っていないのに終了処理を行っていた