### PR TITLE
stable_5_4 向け mfc/#437 の push誤り (取り下げ2) 

### DIFF
--- a/teraterm/teraterm/sendmem.cpp
+++ b/teraterm/teraterm/sendmem.cpp
@@ -89,16 +89,25 @@ typedef struct SendMemTag {
 	CheckEOLData_t *ceol;
 } SendMem;
 
+typedef SendMem *PSendMem;
+
 extern "C" IdTalk TalkStatus;
 extern "C" HWND HVTWin;
 
-static SendMem *sendmem_fifo[10];
+#define SENDMEM_FIFO_ADD_NUM 10
+static PSendMem *sendmem_fifo = NULL;
 static int sendmem_size = 0;
+static int sendmem_max = 0;
 
 static BOOL smptrPush(SendMem *sm)
 {
-	if (sendmem_size >= _countof(sendmem_fifo)) {
-		return FALSE;
+	if (sendmem_size >= sendmem_max) {
+		PSendMem *p = (PSendMem *)realloc(sendmem_fifo, sizeof(PSendMem) * (sendmem_max + SENDMEM_FIFO_ADD_NUM));
+		if (p == NULL) {
+			return FALSE;
+		}
+		sendmem_fifo = p;
+		sendmem_max += SENDMEM_FIFO_ADD_NUM;
 	}
 	sendmem_fifo[sendmem_size] = sm;
 	sendmem_size++;


### PR DESCRIPTION
stable_5_4 向け mfc/https://github.com/TeraTermProject/teraterm/issues/437 の push の間違い2です。
取り下げさせて頂きます。