### PR TITLE
ANSI API選択時、CodePageが無効になっていたので修正 #812

### DIFF
--- a/installer/release/.editorconfig
+++ b/installer/release/.editorconfig
@@ -1,5 +1,0 @@
-[.lng]
-end_of_line = crlf
-charset = utf-8-bom
-trim_trailing_whitespace = true
-insert_final_newline = true

--- a/installer/release/lang_utf8/.editorconfig
+++ b/installer/release/lang_utf8/.editorconfig
@@ -1,3 +1,5 @@
 [*.lng]
 end_of_line = crlf
 charset = utf-8-bom
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/teraterm/teraterm/font_pp.cpp
+++ b/teraterm/teraterm/font_pp.cpp
@@ -244,7 +244,7 @@ static INT_PTR CALLBACK Proc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 				free(s);
 
 				SetDlgItemInt(hWnd, IDC_VTFONT_CODEPAGE_EDIT, ts->VTDrawAnsiCodePage_ini, FALSE);
-				EnableCodePage(hWnd, ts->VTDrawAPI == IdVtDrawAPIUnicode ? FALSE : TRUE);
+				EnableCodePage(hWnd, ts->VTDrawAPI == IdVtDrawAPIANSI ? FALSE : TRUE);
 				SendDlgItemMessageA(hWnd, IDC_VTFONT_CODEPAGE_EDIT, EM_LIMITTEXT, IDC_CODEPAGE_MAXLEN, 0);
 			}
 

--- a/teraterm/teraterm/font_pp.rc
+++ b/teraterm/teraterm/font_pp.rc
@@ -63,12 +63,12 @@ BEGIN
     CONTROL         "List &hidden fonts in font dialog",IDC_LIST_HIDDEN_FONTS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,59,234,10
     LTEXT           "Use the link below to open the Fonts folder and view font visibility",IDC_FONT_FOLDER_LABEL,19,76,320,8
-    LTEXT           "??????",IDC_FONT_FOLDER,28,91,99,8,WS_TABSTOP
+    LTEXT           "C:\\WINDOWS\\Fonts",IDC_FONT_FOLDER,28,91,99,8,WS_TABSTOP
     CONTROL         "Dra&wing resized font to fit cell width",IDC_RESIZED_FONT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,112,178,10
     LTEXT           "API for drawing",IDC_VTFONT_TITLE,7,130,123,8
     COMBOBOX        IDC_VTFONT_COMBO,19,141,106,49,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "&Code page for character conversion(Auto when 0, %d)",IDC_VTFONT_CODEPAGE_LABEL,19,158,218,8
+    LTEXT           "&Code page for character conversion(Auto when 0, %d)",IDC_VTFONT_CODEPAGE_LABEL,19,158,199,8
     EDITTEXT        IDC_VTFONT_CODEPAGE_EDIT,19,171,40,12,ES_AUTOHSCROLL | ES_NUMBER
     LTEXT           "character space",IDC_CHARACTER_SPACE_TITLE,220,114,115,8
     EDITTEXT        IDC_SPACE_TOP,254,134,40,14,ES_AUTOHSCROLL,WS_EX_RIGHT


### PR DESCRIPTION
- フォントタブのコントロールが重ならないよう修正
- .editorconfig 修正
  - 不要な.editorconfigを削除
  - installer/release/lang_utf8/.editorconfig を修正
    - 行末スペース削除など追加