### PR TITLE
Unicode API時にCodePageが有効になる場合があったので修正 #812

### DIFF
--- a/doc/en/html/menu/setup-additional-font.html
+++ b/doc/en/html/menu/setup-additional-font.html
@@ -82,6 +82,12 @@
       <dt id="DrawAPI">API for drawing</dt>
       <dd>
         <dl>
+          <dt>Auto</dt>
+          <dd>
+            Automatically select Unicode/ANSI based on Windows version.<br>
+            Only ANSI is available on Windows 9x.
+          </dd>
+
           <dt>Unicode API</dt>
           <dd>
             Use Unicode Draw API.<br>

--- a/doc/ja/html/menu/setup-additional-font.html
+++ b/doc/ja/html/menu/setup-additional-font.html
@@ -85,6 +85,12 @@
       <dt id="DrawAPI">文字描画で使用するAPI</dt>
       <dd>
         <dl>
+          <dt>Auto</dt>
+          <dd>
+            動作しているWindowsによってUnicode/ANSIを自動で決定します。<br>
+            Windows 9xでは選択できず、ANSIのみとなります。
+          </dd>
+
           <dt>Unicode API</dt>
           <dd>
             Unicodeを直接使用できる描画APIを使用します。<br>

--- a/teraterm/teraterm/font_pp.cpp
+++ b/teraterm/teraterm/font_pp.cpp
@@ -244,7 +244,7 @@ static INT_PTR CALLBACK Proc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 				free(s);
 
 				SetDlgItemInt(hWnd, IDC_VTFONT_CODEPAGE_EDIT, ts->VTDrawAnsiCodePage_ini, FALSE);
-				EnableCodePage(hWnd, ts->VTDrawAPI == IdVtDrawAPIANSI ? FALSE : TRUE);
+				EnableCodePage(hWnd, ts->VTDrawAPI == IdVtDrawAPIANSI ? TRUE : FALSE);
 				SendDlgItemMessageA(hWnd, IDC_VTFONT_CODEPAGE_EDIT, EM_LIMITTEXT, IDC_CODEPAGE_MAXLEN, 0);
 			}
 


### PR DESCRIPTION
- ドキュメントにAutoを追記