### PR TITLE
インストーラー用ライセンスファイルへの TTXChangeFontSize の記載漏れを修正 #599 #770

### DIFF
--- a/installer/release/license.txt
+++ b/installer/release/license.txt
@@ -165,29 +165,3 @@ OF SUCH DAMAGE.
 
 
 
-License of TTXChangeFontSize
-
-Copyright (c) 2022 IWAMOTO Kouichi
-(C) 2025- TeraTerm Project
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
stable_5_4 には TTXChangeFontSize は含まれていないため、PR https://github.com/TeraTermProject/teraterm/pull/770 の修正 [cafcec3](https://github.com/TeraTermProject/teraterm/pull/770/commits/cafcec3b0971a09385ab74c2c12985f0a12945cd)を revert します。