### PR TITLE
マニュアル「Tera Term 2.3, 4, 5 の比較」のライセンスリンク先の修正 (stable_5_5 への反映 #886 抜粋) #890

### DIFF
--- a/doc/en/html/about/difference.html
+++ b/doc/en/html/about/difference.html
@@ -253,7 +253,7 @@ Overview of difference between Teraterm 2.3 (original version) by Takashi Terani
 
 <ul>
   <li id="fn_1">[<a href="#fn_link_1">*1</a>] Without written permission by the author (Takashi Teranishi), you may not distribute modified versions of this package, and may not distribute this package for profit.</li>
-  <li id="fn_2">[<a href="#fn_link_2">*2</a>] Tera Term is distributed under <a href="http://www.opensource.org/licenses/bsd-license.php" target="_blank">Modified BSD License</a>.</li>
+  <li id="fn_2">[<a href="#fn_link_2">*2</a>] Tera Term is distributed under <a href="https://opensource.org/license/bsd-3-clause" target="_blank">Modified BSD License</a>.</li>
   <li id="fn_3">[<a href="#fn_link_3">*3</a>] Icon designer is Tatsuhiko Sakamoto.</li>
   <li id="fn_4">[<a href="#fn_link_4">*4</a>] Tera Term can not simultaneously display multi languages because it has not completely implemented as Unicode API. Now Tera Term mutually converts between Unicode(UCS-2) and MBCS. Also, Chinese version Windows can display Chinese characters when you configure the locale for Unicode.</li>
   <li id="fn_5">[<a href="#fn_link_5">*5</a>] You can switch the message language by using the language file(lang\*.lng). You need to re-startup Tera Term to active new message language.</li>

--- a/doc/ja/html/about/difference.html
+++ b/doc/ja/html/about/difference.html
@@ -254,7 +254,7 @@ Tera Term 原作者 寺西高氏による Tera Term Pro 2.3 (オリジナルバージョン) と、Ter
 
 <ul>
   <li id="fn_1">[<a href="#fn_link_1">*1</a>] 改造版 Tera Term を不特定多数の人に配布する場合には作者（寺西高氏）の許可が必要。ただし、プラグインは除く。いかなる場合においても金銭的利益を得るためにTera Termを配布するには作者（寺西高氏）の許可が必要。</li>
-  <li id="fn_2">[<a href="#fn_link_2">*2</a>] <a href="http://www.opensource.org/licenses/bsd-license.php" target="_blank">修正BSDライセンス</a>に準拠する。</li>
+  <li id="fn_2">[<a href="#fn_link_2">*2</a>] <a href="https://opensource.org/license/bsd-3-clause" target="_blank">修正BSDライセンス</a>に準拠する。</li>
   <li id="fn_3">[<a href="#fn_link_3">*3</a>] アイコンの制作は坂本龍彦氏による。</li>
   <li id="fn_4">[<a href="#fn_link_4">*4</a>] 内部でUnicode(UCS-2)とMBCSとの相互変換を行っているため、多言語同時表示は不可。すなわち、日本語版Windows上で日本語以外の言語を表示することはできない。ロケール設定により、中国語版Windows上でUTF-8による中国語を扱うことは可能。</li>
   <li id="fn_5">[<a href="#fn_link_5">*5</a>] 言語ファイル(lang\*.lng)によりメニューやメッセージの表示言語を切り替えることができる。</li>


### PR DESCRIPTION
#886 から以下の修正のみ抜粋し stable_5_5 に反映します。

下記のリンク先が二条項BSDライセンスになっているため、修正BSDライセンスへのリンクに修正する。
doc/en/html/about/difference.html ： [*2] Tera Term is distributed under Modified BSD License.
doc/ja/html/about/difference.html ： [*2] 修正BSDライセンスに準拠する。