### PR TITLE
Transmitting ZMODEM Hex headers terminated with 0x8D, 0x8A makes no sense and is non-standard #889

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -47,6 +47,10 @@
         Fixed CANCEL is not implemented when YMODEM receiving.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/786" target="_blank">issue #786</a>)
       </li>
+      <li>
+        Modified the CR LF sent in the ZMODEM hex header from 0x8D 0x8A to 0x0D 0x8A.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/889" target="_blank">issue #889</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -47,6 +47,10 @@
         YMODEM 受信時にキャンセル受信処理が実装されていない問題を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/786" target="_blank">issue #786</a>)
       </li>
+      <li>
+        ZMODEM の Hex header で送信する CR LF を 0x8D 0x8A から 0X0D 0x8Aに修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/889" target="_blank">issue #889</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/ttpfile/zmodem.c
+++ b/teraterm/ttpfile/zmodem.c
@@ -336,7 +336,7 @@ static void ZShHdr(PZVar zv, BYTE HdrType)
 	}
 	ZPutHex(zv, &(zv->PktOutCount), HIBYTE(zv->CRC));
 	ZPutHex(zv, &(zv->PktOutCount), LOBYTE(zv->CRC));
-	zv->PktOut[zv->PktOutCount] = 0x8D;
+	zv->PktOut[zv->PktOutCount] = 0x0D;
 	zv->PktOutCount++;
 	zv->PktOut[zv->PktOutCount] = 0x8A;
 	zv->PktOutCount++;
@@ -361,11 +361,6 @@ static void ZShHdr(PZVar zv, BYTE HdrType)
 
 static void ZPutBin(PZVar zv, int *i, BYTE b)
 /*
- * lrzsz では ZDLE(CAN), DLE, XON, XOFF, @ の直後の CR, およびこれらの
- * MSB が立った文字がエスケープ対象となっている。
- * Tera Term では以前は lrzsz と同じだったようだが、何らかの理由で
- * CR は常にエスケープ対象に変わっている。
- *
  * 接続先からさらに ssh / telnet 接続した場合に問題を起こさないよう、
  * LF および GS もデフォルトのエスケープ対象に加える。
  * ssh: LF または CR の直後の ~ がエスケープ文字扱い


### PR DESCRIPTION
ZMODEM の Hex header で送信する CR LF を 0x8D 0x8A から 0X0D 0x8A に修正するPRです。