### PR TITLE
ログファイル名にあわせて設定が変化するよう修正 #896

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -54,6 +54,8 @@
       <li>
         Fixed CANCEL is not implemented when YMODEM receiving.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/786" target="_blank">issue #786</a>)
+        Fixed settings change when log file name is modified in log dialog.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/896" target="_blank">issue #896</a>)
       </li>
     </ul>
   </li>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -54,6 +54,8 @@
       <li>
         YMODEM 受信時にキャンセル受信処理が実装されていない問題を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/786" target="_blank">issue #786</a>)
+        ログダイアログでファイル名を変更したとき、設定が変更されるよう修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/896" target="_blank">issue #896</a>)
       </li>
     </ul>
   </li>

--- a/teraterm/common/win32helper.cpp
+++ b/teraterm/common/win32helper.cpp
@@ -267,6 +267,7 @@ DWORD hGetWindowTextW(HWND hWnd, wchar_t **text)
 DWORD hGetDlgItemTextW(HWND hDlg, int id, wchar_t **text)
 {
 	HWND hWnd = GetDlgItem(hDlg, id);
+	assert(hWnd != NULL);
 	return hGetWindowTextW(hWnd, text);
 }
 
@@ -436,4 +437,31 @@ BOOL hSetupDiGetDevicePropertyW(
 		}
 	}
 	return FALSE;
+}
+
+/**
+ *	リストボックス(コンボボックス)の文字列を取得する
+ *	不要になったら free() すること
+ *
+ *	@param		hDlg	ダイアログのハンドル
+ *	@param		id		コントロール(コンボボックス)のID
+ *	@param		index	リストの通し番号(0-)
+ *	@param[out]	text	設定されている文字列
+ *						不要になったらfree()する
+ *	@return	エラーコード,0(=NO_ERROR)のときエラーなし
+ */
+DWORD hGetDlgItemCBTextW(HWND hDlg, int id, int index, wchar_t **text)
+{
+	HWND hWnd = GetDlgItem(hDlg, id);
+	assert(hWnd != NULL);
+	LRESULT len = SendMessageW(hWnd, CB_GETLBTEXTLEN, index, 0);
+	wchar_t *strW = (wchar_t *)malloc((size_t(len) + 1) * sizeof(wchar_t));
+	if (strW == NULL) {
+		*text = NULL;
+		return ERROR_NOT_ENOUGH_MEMORY;
+	}
+	SendMessageW(hWnd, CB_GETLBTEXT, index, (LPARAM)strW);
+	strW[len] = 0;
+	*text = strW;
+	return NO_ERROR;
 }

--- a/teraterm/common/win32helper.h
+++ b/teraterm/common/win32helper.h
@@ -56,6 +56,7 @@ BOOL hSetupDiGetDevicePropertyW(
 	HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData,
 	const DEVPROPKEY *PropertyKey,
 	void **buf, size_t *buf_size);
+DWORD hGetDlgItemCBTextW(HWND hDlg, int id, int index, wchar_t **text);
 
 #ifdef __cplusplus
 }

--- a/teraterm/teraterm/log_pp.cpp
+++ b/teraterm/teraterm/log_pp.cpp
@@ -349,9 +349,7 @@ BOOL CLogPropPageDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 			if (wParam == (IDC_DEFAULTNAME_EDITOR | (CBN_SELCHANGE << 16))) {
 				LRESULT r = SendDlgItemMessageW(IDC_DEFAULTNAME_EDITOR, CB_GETCURSEL, 0, 0);
 				if (r != CB_ERR) {
-					LRESULT len = SendDlgItemMessageW(IDC_DEFAULTNAME_EDITOR, CB_GETLBTEXTLEN, r, 0);
-					format = (wchar_t*)malloc((len + 1) * sizeof(wchar_t));
-					SendDlgItemMessageW(IDC_DEFAULTNAME_EDITOR, CB_GETLBTEXT, r, (LPARAM)format);
+					hGetDlgItemCBTextW(m_hWnd, IDC_DEFAULTNAME_EDITOR, r, &format);
 				}
 			}
 			if (format == NULL) {

--- a/teraterm/teraterm/logdlg.cpp
+++ b/teraterm/teraterm/logdlg.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * (C) 2023- TeraTerm Project
  * All rights reserved.
  *
@@ -227,6 +227,28 @@ static void ArrangeControls(HWND Dialog, LogDlgWork_t *work)
 	}
 }
 
+/**
+ * ログファイルをチェックして、
+ * ラジオボタン、ファイルの状態からコントロールをEnable/Disableする
+ */
+static void ArrangeControlsFilename(HWND Dialog, LogDlgWork_t *work, const wchar_t *filename)
+{
+	const bool file_exist_prev = work->file_exist;
+	CheckLogFile(filename, work);
+	if (work->on_initdialog || file_exist_prev != work->file_exist) {
+		if (work->file_exist) {
+			// ファイルが存在する、設定に合わせて新規(上書き)/追記を選択する
+			CheckRadioButton(Dialog, IDC_NEW_OVERWRITE, IDC_APPEND,
+							 work->pts->Append == 0 ? IDC_NEW_OVERWRITE : IDC_APPEND);
+		}
+		else {
+			// ファイルが存在しない、新規を選択する
+			CheckRadioButton(Dialog, IDC_NEW_OVERWRITE, IDC_APPEND, IDC_NEW_OVERWRITE);
+		}
+		ArrangeControls(Dialog, work);
+	}
+}
+
 static LRESULT CALLBACK FNameEditProc(HWND dlg, UINT msg,
 									  WPARAM wParam, LPARAM lParam)
 {
@@ -324,6 +346,8 @@ static INT_PTR CALLBACK LogFnHook(HWND Dialog, UINT Message, WPARAM wParam, LPAR
 		//		WM_COMMAND, EN_CHANGE が発生する
 		wchar_t *fname = FLogGetLogFilename(work->info->filename);
 		SetDlgItemTextW(Dialog, IDC_FOPT_FILENAME_EDIT, fname);
+		ArrangeControlsFilename(Dialog, work, fname);
+		free(fname);
 
 		// ドロップダウンのエディットコントロールのウィンドウハンドルを取得
 		COMBOBOXINFO cbi;
@@ -337,7 +361,6 @@ static INT_PTR CALLBACK LogFnHook(HWND Dialog, UINT Message, WPARAM wParam, LPAR
 
 		HistoryStoreSetControl(hs, Dialog, IDC_FOPT_FILENAME_EDIT);
 		ExpandCBWidth(Dialog, IDC_FOPT_FILENAME_EDIT);
-		free(fname);
 
 		CenterWindow(Dialog, GetParent(Dialog));
 
@@ -401,6 +424,7 @@ static INT_PTR CALLBACK LogFnHook(HWND Dialog, UINT Message, WPARAM wParam, LPAR
 			BOOL Ok = TTGetSaveFileNameW(&ofn, &fname);
 			if (Ok) {
 				SetDlgItemTextW(Dialog, IDC_FOPT_FILENAME_EDIT, fname);
+				ArrangeControlsFilename(Dialog, work, fname);
 				free(fname);
 			}
 			free(logdir);
@@ -419,24 +443,19 @@ static INT_PTR CALLBACK LogFnHook(HWND Dialog, UINT Message, WPARAM wParam, LPAR
 			break;
 		case IDC_FOPT_FILENAME_EDIT:
 			switch (HIWORD(wParam)) {
-			case EN_CHANGE: {
+			case CBN_EDITCHANGE: {
 				wchar_t *filename;
 				hGetDlgItemTextW(Dialog, IDC_FOPT_FILENAME_EDIT, &filename);
-				const bool file_exist_prev = work->file_exist;
-				CheckLogFile(filename, work);
+				ArrangeControlsFilename(Dialog, work, filename);
 				free(filename);
-				if (work->on_initdialog || file_exist_prev != work->file_exist) {
-					if (work->file_exist) {
-						// ファイルが存在する、設定に合わせて新規(上書き)/追記を選択する
-						CheckRadioButton(Dialog, IDC_NEW_OVERWRITE, IDC_APPEND,
-										 work->pts->Append == 0 ? IDC_NEW_OVERWRITE : IDC_APPEND);
-					}
-					else {
-						// ファイルが存在しない、新規を選択する
-						CheckRadioButton(Dialog, IDC_NEW_OVERWRITE, IDC_APPEND, IDC_NEW_OVERWRITE);
-					}
-					ArrangeControls(Dialog, work);
-				}
+				break;
+			}
+			case CBN_SELCHANGE: {
+				int cursor = (int)SendDlgItemMessageA(Dialog, IDC_FOPT_FILENAME_EDIT, CB_GETCURSEL, 0, 0);
+				wchar_t *filename;
+				hGetDlgItemCBTextW(Dialog, IDC_FOPT_FILENAME_EDIT, cursor, &filename);
+				ArrangeControlsFilename(Dialog, work, filename);
+				free(filename);
 				break;
 			}
 			case CBN_DROPDOWN: {
@@ -456,6 +475,7 @@ static INT_PTR CALLBACK LogFnHook(HWND Dialog, UINT Message, WPARAM wParam, LPAR
 		CheckRadioButton(Dialog, IDC_NEW_OVERWRITE, IDC_APPEND, IDC_APPEND);
 		SetDlgItemTextW(Dialog, IDC_FOPT_FILENAME_EDIT, filename);
 		SendDlgItemMessageW(Dialog, IDC_FOPT_FILENAME_EDIT, EM_SETSEL, 0, -1);
+		ArrangeControlsFilename(Dialog, work, filename);
 		free(filename);
 		return TRUE;
 	}
@@ -466,8 +486,9 @@ static INT_PTR CALLBACK LogFnHook(HWND Dialog, UINT Message, WPARAM wParam, LPAR
 			break;
 		}
 		wchar_t *fname = FLogGetLogFilename(work->info->filename);
-		SetWindowTextW(work->file_edit, fname);
+		SetDlgItemTextW(Dialog, IDC_FOPT_FILENAME_EDIT, fname);
 		SendMessageW(work->file_edit, EM_SETSEL, 0, -1);
+		ArrangeControlsFilename(Dialog, work, fname);
 		free(fname);
 		break;
 	}


### PR DESCRIPTION
- ファイル名を変更しても設定が変わらなくなっていた
  - デフォルトが追記設定なら、存在するファイル名を入れると追記になる、など
- エディットボックスをコンボボックスに変更したときに入った不具合
  - 077e9b9bc473dcdcf679b3790d571972b3a8364e
  - #402
- hGetDlgItemCBTextW() 追加
  - コンボボックスのドロップダウンから文字列を取得

(cherry picked from commit 424341dfe31f96cdb8a738397aa17121469a8734)