### PR TITLE
ANSI版のiniファイル書き込みAPIをUnicode版に置き換え #929

### DIFF
--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -1675,27 +1675,6 @@ LRESULT CVTWindow::OnUniChar(WPARAM wParam, LPARAM lParam)
 	return FALSE;
 }
 
-/* copy from ttset.c*/
-static void WriteInt2(const char *Sect, const char *Key, const char *FName, int i1, int i2)
-{
-	char Temp[32];
-	_snprintf_s(Temp, sizeof(Temp), _TRUNCATE, "%d,%d", i1, i2);
-	WritePrivateProfileString(Sect, Key, Temp, FName);
-}
-
-static void SaveVTPos()
-{
-#define Section "Tera Term"
-	if (ts.SaveVTWinPos) {
-		/* VT win position */
-		WriteInt2(Section, "VTPos", ts.SetupFName, ts.VTPos.x, ts.VTPos.y);
-
-		/* VT terminal size  */
-		WriteInt2(Section, "TerminalSize", ts.SetupFName,
-		          ts.TerminalWidth, ts.TerminalHeight);
-	}
-}
-
 void CVTWindow::OnClose()
 {
 	if ((HTEKWin!=NULL) && ! ::IsWindowEnabled(HTEKWin)) {
@@ -1722,7 +1701,7 @@ void CVTWindow::OnClose()
 	FileSendEnd();
 	ProtoEnd();
 
-	SaveVTPos();
+	SaveVTPos(&ts);
 	Notify2UnsetWindow((NotifyIcon *)cv.NotifyIcon);
 
 	// アプリケーション終了時にアイコンを破棄すると、ウィンドウが消える前に

--- a/teraterm/ttpset/ttset.c
+++ b/teraterm/ttpset/ttset.c
@@ -3318,6 +3318,18 @@ void PASCAL _WriteIniFile(const wchar_t *FName, PTTSet ts)
 
 }
 
+void SaveVTPos(const PTTSet ts)
+{
+	if (ts->SaveVTWinPos) {
+		/* VT win position */
+		WriteInt2(Section, "VTPos", ts->SetupFNameW, ts->VTPos.x, ts->VTPos.y);
+
+		/* VT terminal size  */
+		WriteInt2(Section, "TerminalSize", ts->SetupFNameW,
+		          ts->TerminalWidth, ts->TerminalHeight);
+	}
+}
+
 void PASCAL _CopySerialList(const wchar_t *IniSrc, const wchar_t *IniDest, const wchar_t *section,
 							const wchar_t *key, int MaxList)
 {

--- a/teraterm/ttpset/ttset.h
+++ b/teraterm/ttpset/ttset.h
@@ -36,6 +36,7 @@ extern "C" {
 typedef struct TKeyMap_st *PKeyMap;
 
 BOOL ParseFOption(PTTSet ts);
+void SaveVTPos(const PTTSet ts);
 
 void PASCAL _ReadIniFile(const wchar_t *FName, PTTSet ts);
 void PASCAL _WriteIniFile(const wchar_t *FName, PTTSet ts);


### PR DESCRIPTION
- WritePrivateProfileStringA() を WritePrivateProfileStringW() へ変更
- VTWinの位置とサイズをiniファイルに書き込む関数(SaveVTPos()) を ttset.c へ移動