### PR TITLE
mingwでビルドできるよう修正 #928

### DIFF
--- a/teraterm/teraterm/setupdirdlg.cpp
+++ b/teraterm/teraterm/setupdirdlg.cpp
@@ -556,7 +556,7 @@ static INT_PTR CALLBACK OnSetupDirectoryDlgProc(HWND hDlgWnd, UINT msg, WPARAM w
 			{ NULL, L"UI language file",
 			  LIST_PARAM_STR, pts->UILanguageFileW, NULL },
 			{ NULL, L"Broadcast history file",
-			  LIST_PARAM_FUNC, GetHistoryFileName, NULL },
+			  LIST_PARAM_FUNC, (void*)GetHistoryFileName, NULL },
 		};
 
 		int y = 0;


### PR DESCRIPTION
- error: invalid conversion from 'wchar_t* (*)(const SetupList*, const TTTSet*)' {aka 'wchar_t* (*)(const SetupList*, const tttset*)'} to 'void*' [-fpermissive]