### PR TITLE
OPENFILENAMEW.lStructSize に設定する値を修正 #1001

### DIFF
--- a/teraterm/teraterm/filesys_proto.cpp
+++ b/teraterm/teraterm/filesys_proto.cpp
@@ -728,7 +728,7 @@ static wchar_t **_GetXFname(HWND HWin, BOOL Receive, const wchar_t *caption, LPL
 	}
 
 	OPENFILENAMEW ofn = {};
-	ofn.lStructSize = get_OPENFILENAME_SIZE();
+	ofn.lStructSize = get_OPENFILENAME_SIZEW();
 	ofn.hwndOwner   = HWin;
 	ofn.lpstrFilter = FNFilter;
 	ofn.nFilterIndex = 1;
@@ -998,7 +998,7 @@ static wchar_t **_GetMultiFname(HWND hWnd, WORD FuncId, const wchar_t *caption, 
 	}
 
 	OPENFILENAMEW ofn = {};
-	ofn.lStructSize = get_OPENFILENAME_SIZE();
+	ofn.lStructSize = get_OPENFILENAME_SIZEW();
 	ofn.hwndOwner   = hWnd;
 	ofn.lpstrFilter = FNFilter;
 	ofn.nFilterIndex = 1;
@@ -1598,7 +1598,7 @@ static wchar_t **_GetTransFname(HWND hWnd, const wchar_t *DlgCaption)
 
 	FileName[0] = 0;
 	OPENFILENAMEW ofn = {};
-	ofn.lStructSize = get_OPENFILENAME_SIZE();
+	ofn.lStructSize = get_OPENFILENAME_SIZEW();
 	ofn.hwndOwner   = hWnd;
 	ofn.lpstrFilter = FNFilter;
 	ofn.nFilterIndex = 1;


### PR DESCRIPTION
- 修正前はANSI版のサイズを設定していた

(cherry picked from commit 5096843990762755f9f21fee68ebeb0479896f53)