### PR TITLE
.editorconfig から *.rc をコメントアウト #979

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -74,6 +74,8 @@ end_of_line = crlf
 end_of_line = lf
 charset = utf-8
 
-[*.rc]
-end_of_line = crlf
-charset = utf-8
+; Visual StudioのリソースエディタがANSIで出力するようです
+; なるべく文字コードはASCIIの範囲で使用してください
+;[*.rc]
+;end_of_line = crlf
+;charset = utf-8


### PR DESCRIPTION
- リソースコンパイラはUTF-8のrcファイルを受け付けるようだ
- Visual StudioのリソースエディタがANSIで出力するようだ
- 日本語Windows以外での環境ではどうなるか未検証
- 文字コードをUTF-8にしてよいか確定できない
- なるべくASCIIの範囲で使用するようコメントを入れて無効化した