### PR TITLE
文字選択時表示のちらつきを減らす #1005

### DIFF
--- a/teraterm/teraterm/vtdisp.c
+++ b/teraterm/teraterm/vtdisp.c
@@ -2330,8 +2330,12 @@ ttdc_t *PaintWindow(vtdraw_t *vt, HDC PaintDC, RECT PaintRect, BOOL fBkGnd,
 	dc->VTDC = hDC;
 	DispInitDC2(vt, dc);
 
+	// 領域の塗りつぶし
+	//  文字間が全て0の時、文字の描画だけで全領域が描画できるので、塗りつぶし不要
 	if(!BGEnable && fBkGnd) {
-		FillRect(hDC, &PaintRect, vt->Background);
+		if (ts.FontDW != 0 || ts.FontDH != 0 || ts.FontDX != 0 || ts.FontDY != 0){
+			FillRect(hDC, &PaintRect, vt->Background);
+		}
 	}
 
 	*Xs = PaintRect.left / vt->FontWidth + WinOrgX;

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -5297,6 +5297,14 @@ LRESULT CVTWindow::Proc(UINT msg, WPARAM wp, LPARAM lp)
 	case WM_PAINT:
 		OnPaint();
 		break;
+	case WM_ERASEBKGND:
+		// 背景消去を DefWindowProc() に行わせない(DefWindowProc()を呼ばない)
+		//		DefWindowProc() は背景を塗りつぶすが、
+		//		WNDCLASSW.hbrBackground = NULL なので何も行わない
+		// 0を返すと背景が塗りつぶしが行われていない、と判定される
+		//		WM_PAINTで PAINTSTRUCT.fErase = TRUE となる
+		retval = 0;
+		break;
 	case WM_RBUTTONDOWN:
 		OnRButtonDown((UINT)wp, MAKEPOINTS(lp));
 		break;


### PR DESCRIPTION
- PaintWindow()
  - 不要な背景塗りつぶしを行わない
- WM_ERASEBKGND
  - 何もしない、DefWindowProc()を使わない
  - 念のため