### PR TITLE
Fix/#1020 key bits

### DIFF
--- a/ttssh2/ttxssh/ssh.c
+++ b/ttssh2/ttxssh/ssh.c
@@ -5869,6 +5869,7 @@ static BOOL handle_SSH2_dh_kex_reply(PTInstVar pvar)
 	}
 	buffer_clear(server_blob);
 	buffer_put_string(server_blob, server_public, pklen);
+	buffer_rewind(server_blob);
 	buffer_get_bignum2_msg(server_blob, dh_server_pub);
 	kex->server_key_bits = BN_num_bits(dh_server_pub);
 


### PR DESCRIPTION
固定グループ DH の鍵交換のとき、サーバ公開鍵のビット数が表示されない問題を修正 #1020

2b4863e で発生