### PR TITLE
32bitでコンパイル時にエラーが出ないよう修正 #1017

### DIFF
--- a/teraterm/teraterm/teraprn.cpp
+++ b/teraterm/teraterm/teraprn.cpp
@@ -144,7 +144,7 @@ static void PrnDestroyDialog()
  *	@retval	TRUE	印刷ジョブを続行
  *	@retval	FALSE	印刷ジョブを取り消す
  */
-static BOOL PrnAbortProc(HDC hDC, int Error)
+static BOOL CALLBACK PrnAbortProc(HDC hDC, int Error)
 {
 	(void)hDC;
 	(void)Error;


### PR DESCRIPTION
- teraprn.cpp(183,4): error C2664: 'int SetAbortProc(HDC,ABORTPROC)': cannot convert argument 2 from 'BOOL (__cdecl *)(HDC,int)' to 'ABORTPROC'