### PR TITLE
Fix/#1037 fail workflow job

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -69,7 +69,7 @@ jobs:
         RELEASE: ${{ steps.vars.outputs.RELEASE }}
       run: |
         chcp 932
-        installer\release.bat 10
+        installer\release.bat 10 || exit /b 1
 
     - name: Save cache files (buildtools)
       id: cache-buildtools-save
@@ -180,10 +180,10 @@ jobs:
       run: |
         chcp 932
         if "%RELEASE%"=="0" (
-          installer\release.bat 13
+          installer\release.bat 13 || exit /b 1
         ) else (
           rem for release build
-          installer\release.bat 11
+          installer\release.bat 11 || exit /b 1
         )
 
     - name: Upload to artifacts (teraterm_common)
@@ -350,10 +350,10 @@ jobs:
       run: |
         chcp 932
         if "%RELEASE%"=="0" (
-          installer\release.bat 14
+          installer\release.bat 14 || exit /b 1
         ) else (
           rem for release build
-          installer\release.bat 12
+          installer\release.bat 12 || exit /b 1
         )
 
     - name: Clean up files before caching


### PR DESCRIPTION
ビルド失敗（release.bat 異常終了）時に、ワークフローのジョブを失敗させる #1037