### PR TITLE
enum scp_dir を ssh.h へ移動した #1057

### DIFF
--- a/ttssh2/ttxssh/ssh.c
+++ b/ttssh2/ttxssh/ssh.c
@@ -100,11 +100,6 @@ typedef enum {
 	GetPayloadTruncate = 2
 } PayloadStat;
 
-enum scp_dir {
-	TOREMOTE,
-	FROMREMOTE,
-};
-
 static struct global_confirm global_confirms;
 
 static Channel_t *channels = NULL;  // チャネル構造体の配列

--- a/ttssh2/ttxssh/ssh.h
+++ b/ttssh2/ttxssh/ssh.h
@@ -357,6 +357,10 @@ typedef struct Key {
 } Key;
 
 
+enum scp_dir {
+	TOREMOTE, FROMREMOTE,
+};
+
 /* The packet handler returns TRUE to keep the handler in place,
    FALSE to remove the handler. */
 typedef BOOL (* SSHPacketHandler)(PTInstVar pvar);


### PR DESCRIPTION
- error: field 'dir' has incomplete type
- 経緯
  - enum scp_dir は参照されていないため、ssh.c へ移動したが、実際は参照されていた
  - Visual Studioでエラーなくビルドできていた
  - gcc,clangでビルドエラーが出た