### PR TITLE
Fix/#1080 alt_t AYT

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -96,6 +96,10 @@
         Fixed an issue Cancel button in printing dialog is not working when printing from print menu ("File &gt; <a href="../menu/file-print.html">Print...</a>").
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1017" target="_blank">issue #1017</a>)
       </li>
+      <li>
+        Fixed an issue where the Alt+T access key sent the AYT (Are You There) command even when the active TCP/IP connection was not TELNET.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1086" target="_blank">issue #1086</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -96,6 +96,10 @@
         印刷 ("File &gt; <a href="../menu/file-print.html">Print...</a>") 時、印刷中ダイアログのCancelボタンで中断できるよう修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1017" target="_blank">issue #1017</a>)
       </li>
+      <li>
+        TELNET 接続中でなくても TCP/IP 接続中なら Alt+T アクセスキーで AYT (Are You There) コマンドが送出される問題を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1086" target="_blank">issue #1086</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -4875,7 +4875,7 @@ void CVTWindow::OnControlResetRemoteTitle()
 
 void CVTWindow::OnControlAreYouThere()
 {
-	if (cv.Ready && (cv.PortType==IdTCPIP)) {
+	if (cv.Ready && (cv.PortType==IdTCPIP) && cv.TelFlag) {
 		TelSendAYT();
 	}
 }


### PR DESCRIPTION
TELNET でなくても TCP/IP 接続中なら Alt+T で AYT が送信される問題を修正 #1086

メニューは TELNET ではないときに無効になっているが、メニューが無効でもアクセスキーは効くようだ