### PR TITLE
TTTSet.SetupFName の参照を無くした #1101

### DIFF
--- a/teraterm/common/tttypes.h
+++ b/teraterm/common/tttypes.h
@@ -294,7 +294,7 @@ struct tttset {
 	char HomeDir[MAXPATHLEN];		// 個人設定ファイルのあるフォルダ switch HomeDirW
 
 	/* Setup file name */
-	char SetupFName[MAX_PATH];
+	char SetupFName[MAX_PATH];			// "TERATERM.INI" のフルパス ANSI版
 	char reserve_KeyCnfFN[MAX_PATH];	// switch KeyCnfFNW
 	char LogFN[MAX_PATH];
 	char reserve_MacroFN[MAX_PATH];		// switch MacroFNW

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -1378,23 +1378,6 @@ void CVTWindow::ResetSetup()
 
 void CVTWindow::RestoreSetup()
 {
-	char TempDir[MAXPATHLEN];
-	char TempName[MAX_PATH];
-
-	if ( strlen(ts.SetupFName)==0 ) {
-		return;
-	}
-
-	ExtractFileName(ts.SetupFName,TempName,sizeof(TempName));
-	ExtractDirName(ts.SetupFName,TempDir);
-	if (TempDir[0]==0)
-		strncpy_s(TempDir, sizeof(TempDir),ts.HomeDir, _TRUNCATE);
-	FitFileName(TempName,sizeof(TempName),".INI");
-
-	strncpy_s(ts.SetupFName, sizeof(ts.SetupFName),TempDir, _TRUNCATE);
-	AppendSlash(ts.SetupFName,sizeof(ts.SetupFName));
-	strncat_s(ts.SetupFName,sizeof(ts.SetupFName),TempName,_TRUNCATE);
-
 	if (LoadTTSET()) {
 		(*ReadIniFile)(ts.SetupFNameW, &ts);
 


### PR DESCRIPTION
- TTTSet.SetupFNameW を参照するよう変更
  - TTTSet.SetupFName (TERATERM.INIのANSIフルパス)を参照する箇所を無くした
- TTTSet.SetupFName にフルパスをセットするコードは残した
  - Tera Term Project外のプラグインが参照しているかもしれないため