### PR TITLE
doc/en/html/usage/tips/data_drop.html の誤記の修正 #1110

### DIFF
--- a/doc/en/html/usage/tips/data_drop.html
+++ b/doc/en/html/usage/tips/data_drop.html
@@ -23,10 +23,10 @@ Tera Term ---> Send buffer  ---> OS,driver ---> (sshd,telnet,pipe) ---> UART chi
 </pre>
 
 <dl>
-  <dt>s1. Sned buffer in Tera Term</dt>
+  <dt>s1. Send buffer in Tera Term</dt>
   <dd>
     It is unlikely to drop.<br>
-    Data is sended while watching free size of send buffer OutBuff[](16KB).
+    Data is sent while monitoring free size of send buffer OutBuff[](16KB).
   </dd>
   <dt>s2. OS,UART chip(sender)</dt>
   <dd>


### PR DESCRIPTION
doc/en/html/usage/tips/data_drop.html の下記の誤記の修正です。

誤 s1. Sned buffer in Tera Term
正 s1. Send buffer in Tera Term

誤 Data is sended while ～
正 Data is sent while ～