### PR TITLE
設定フォルダダイアログをリサイズできるようにする #1106 (マージ不要、取り下げ)

### DIFF
--- a/teraterm/common/edithistory.cpp
+++ b/teraterm/common/edithistory.cpp
@@ -293,6 +293,12 @@ static INT_PTR CALLBACK TCPIPDlg(HWND Dialog, UINT Message, WPARAM wParam, LPARA
 			break;
 		}
 
+		case WM_DPICHANGED: {
+			DlgData *data = (DlgData *)GetWindowLongPtrW(Dialog, DWLP_USER);
+			ReiseDlgHelper_WM_DPICHANGED(data->resize_helper, wParam, lParam);
+			break;
+		}
+
 		case WM_DESTROY: {
 			DlgData *data = (DlgData *)GetWindowLongPtrW(Dialog, DWLP_USER);
 			ReiseDlgHelperDelete(data->resize_helper);

--- a/teraterm/common/resize_helper.cpp
+++ b/teraterm/common/resize_helper.cpp
@@ -248,6 +248,7 @@ void ReiseDlgHelper_WM_GETMINMAXINFO(ReiseDlgHelper_t *h, LPARAM lp)
 	// 初期サイズを最小サイズとする
 	// 現在のDPIに合わせてスケーリング
 	LPMINMAXINFO pmmi = (LPMINMAXINFO)lp;
+	h->dpi = GetMonitorDpiFromWindow(h->hWnd);
 	pmmi->ptMinTrackSize.x = MulDiv(h->init_width, h->dpi, h->init_dpi);
 	pmmi->ptMinTrackSize.y = MulDiv(h->init_height, h->dpi, h->init_dpi);
 }
@@ -255,7 +256,7 @@ void ReiseDlgHelper_WM_GETMINMAXINFO(ReiseDlgHelper_t *h, LPARAM lp)
 void ReiseDlgHelper_WM_DPICHANGED(ReiseDlgHelper_t *h, WPARAM wp, LPARAM lp)
 {
 	assert(h != NULL);
-	UINT new_dpi = LOWORD(wp);
+	UINT new_dpi = HIWORD(wp);
 	//OutputDebugPrintf("WM_DPICHANGED dpi %d->%d\n", h->dpi, new_dpi);
 	h->dpi = new_dpi;
 
@@ -268,6 +269,11 @@ void ReiseDlgHelper_WM_DPICHANGED(ReiseDlgHelper_t *h, WPARAM wp, LPARAM lp)
 		rect->right - rect->left,
 		rect->bottom - rect->top,
 		SWP_NOZORDER | SWP_NOACTIVATE);
+
+	ArrangeControls(h);
+	if (h->hWndSizeBox != NULL) {
+		SetSizeBoxPos(h);
+	}
 }
 
 ReiseDlgHelper_t *ReiseHelperInit(HWND dlg, BOOL size_box, const ResizeHelperInfo *infos, size_t info_count)

--- a/teraterm/teraterm/setupdirdlg.cpp
+++ b/teraterm/teraterm/setupdirdlg.cpp
@@ -719,6 +719,12 @@ static INT_PTR CALLBACK OnSetupDirectoryDlgProc(HWND hDlgWnd, UINT msg, WPARAM w
 		break;
 	}
 
+	case WM_DPICHANGED: {
+		dlg_data_t *dlg_data = (dlg_data_t *)GetWindowLongPtrW(hDlgWnd, DWLP_USER);
+		ReiseDlgHelper_WM_DPICHANGED(dlg_data->resize_helper, wp, lp);
+		break;
+	}
+
 	default:
 		return FALSE;
 	}

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -2289,6 +2289,7 @@ static INT_PTR CALLBACK TTXAboutDlg(HWND dlg, UINT msg, WPARAM wParam, LPARAM lP
 			SendDlgItemMessage(dlg, IDC_ABOUTTEXT, WM_SETFONT, (WPARAM)data->DlgAboutTextFont, MAKELPARAM(TRUE, 0));
 		}
 		SendDlgItemMessage(dlg, IDC_TTSSH_ICON, WM_DPICHANGED, wParam, lParam);
+		ReiseDlgHelper_WM_DPICHANGED(data->resize_helper, wParam, lParam);
 		return FALSE;
 	}
 


### PR DESCRIPTION
設定フォルダダイアログをリサイズできるようにする #1106 の WM_DPICHANGED対応 試作版、修正内容連絡用です。
マージ不要ですので取り下げさせて頂きます。