### PR TITLE
設定フォルダダイアログをリサイズできるようにする #1106 (マージ不要、取り下げ)

### DIFF
--- a/teraterm/common/edithistory.cpp
+++ b/teraterm/common/edithistory.cpp
@@ -293,6 +293,11 @@ static INT_PTR CALLBACK TCPIPDlg(HWND Dialog, UINT Message, WPARAM wParam, LPARA
 			break;
 		}
 
+		case WM_GETDPISCALEDSIZE: {
+			DlgData *data = (DlgData *)GetWindowLongPtrW(Dialog, DWLP_USER);
+			return ReiseDlgHelper_WM_GETDPISCALEDSIZE(data->resize_helper, wParam, lParam);
+		}
+
 		case WM_DPICHANGED: {
 			DlgData *data = (DlgData *)GetWindowLongPtrW(Dialog, DWLP_USER);
 			ReiseDlgHelper_WM_DPICHANGED(data->resize_helper, wParam, lParam);

--- a/teraterm/common/resize_helper.cpp
+++ b/teraterm/common/resize_helper.cpp
@@ -29,6 +29,7 @@
 #include <windows.h>
 #include <assert.h>
 
+#include "compat_win.h"
 #include "resize_helper.h"
 
 #include "ttlib.h"		// for GetMonitorDpiFromWindow()
@@ -251,6 +252,52 @@ void ReiseDlgHelper_WM_GETMINMAXINFO(ReiseDlgHelper_t *h, LPARAM lp)
 	h->dpi = GetMonitorDpiFromWindow(h->hWnd);
 	pmmi->ptMinTrackSize.x = MulDiv(h->init_width, h->dpi, h->init_dpi);
 	pmmi->ptMinTrackSize.y = MulDiv(h->init_height, h->dpi, h->init_dpi);
+}
+
+BOOL ReiseDlgHelper_WM_GETDPISCALEDSIZE(ReiseDlgHelper_t *h, WPARAM wp, LPARAM lp)
+{
+	assert(h != NULL);
+	UINT new_dpi = HIWORD(wp);
+
+	RECT client_rect;
+	GetClientRect(h->hWnd, &client_rect);
+	int tmpScreenWidth = client_rect.right - client_rect.left;
+	int tmpScreenHeight = client_rect.bottom - client_rect.top;
+
+	// Client Areaのサイズからウィンドウサイズを算出
+	if (pAdjustWindowRectExForDpi != NULL || pAdjustWindowRectEx != NULL) {
+		const DWORD Style = (DWORD)::GetWindowLongPtr(h->hWnd, GWL_STYLE);
+		const DWORD ExStyle = (DWORD)::GetWindowLongPtr(h->hWnd, GWL_EXSTYLE);
+		const BOOL bMenu = FALSE; // メニューは無しの想定
+		if (pGetSystemMetricsForDpi != NULL) {
+			// スクロールバーが表示されている場合は、
+			// スクリーンサイズ(クライアントエリアのサイズ)に追加する
+			int min_pos;
+			int max_pos;
+			GetScrollRange(h->hWnd, SB_VERT, &min_pos, &max_pos);
+			if (min_pos != max_pos) {
+				tmpScreenWidth += pGetSystemMetricsForDpi(SM_CXVSCROLL, new_dpi);
+			}
+			GetScrollRange(h->hWnd, SB_HORZ, &min_pos, &max_pos);
+			if (min_pos != max_pos) {
+				tmpScreenHeight += pGetSystemMetricsForDpi(SM_CXHSCROLL, new_dpi);
+			}
+		}
+		RECT Rect = {0, 0, tmpScreenWidth, tmpScreenHeight};
+		if (pAdjustWindowRectExForDpi != NULL) {
+			// Windows 10, version 1607+
+			pAdjustWindowRectExForDpi(&Rect, Style, bMenu, ExStyle, new_dpi);
+		}
+		else {
+			// Windows 2000+
+			pAdjustWindowRectEx(&Rect, Style, bMenu, ExStyle);
+		}
+		SIZE *sz = (SIZE *)lp;
+		sz->cx = Rect.right - Rect.left;
+		sz->cy = Rect.bottom - Rect.top;
+		return TRUE;
+	}
+	return FALSE;
 }
 
 void ReiseDlgHelper_WM_DPICHANGED(ReiseDlgHelper_t *h, WPARAM wp, LPARAM lp)

--- a/teraterm/common/resize_helper.h
+++ b/teraterm/common/resize_helper.h
@@ -100,6 +100,7 @@ ReiseDlgHelper_t *ReiseHelperInit(HWND dlg, BOOL size_box, const ResizeHelperInf
  */
 void ReiseDlgHelper_WM_SIZE(ReiseDlgHelper_t *h, WPARAM wp, LPARAM lp);
 void ReiseDlgHelper_WM_GETMINMAXINFO(ReiseDlgHelper_t *h, LPARAM lp);
+BOOL ReiseDlgHelper_WM_GETDPISCALEDSIZE(ReiseDlgHelper_t *h, WPARAM wp, LPARAM lp);
 void ReiseDlgHelper_WM_DPICHANGED(ReiseDlgHelper_t *h, WPARAM wp, LPARAM lp);
 
 #ifdef __cplusplus

--- a/teraterm/teraterm/setupdirdlg.cpp
+++ b/teraterm/teraterm/setupdirdlg.cpp
@@ -713,6 +713,11 @@ static INT_PTR CALLBACK OnSetupDirectoryDlgProc(HWND hDlgWnd, UINT msg, WPARAM w
 		break;
 	}
 
+	case WM_GETDPISCALEDSIZE: {
+		dlg_data_t *dlg_data = (dlg_data_t *)GetWindowLongPtrW(hDlgWnd, DWLP_USER);
+		return ReiseDlgHelper_WM_GETDPISCALEDSIZE(dlg_data->resize_helper, wp, lp);
+	}
+
 	case WM_GETMINMAXINFO: {
 		dlg_data_t *dlg_data = (dlg_data_t *)GetWindowLongPtrW(hDlgWnd, DWLP_USER);
 		ReiseDlgHelper_WM_GETMINMAXINFO(dlg_data->resize_helper, lp);

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -2279,6 +2279,11 @@ static INT_PTR CALLBACK TTXAboutDlg(HWND dlg, UINT msg, WPARAM wParam, LPARAM lP
 		break;
 	}
 
+	case WM_GETDPISCALEDSIZE: {
+		AboutDlgData *data = (AboutDlgData *)GetWindowLongPtr(dlg, DWLP_USER);
+		return ReiseDlgHelper_WM_GETDPISCALEDSIZE(data->resize_helper, wParam, lParam);
+	}
+
 	case WM_DPICHANGED: {
 		AboutDlgData *data = (AboutDlgData *)GetWindowLongPtr(dlg, DWLP_USER);
 		if (data->DlgAboutTextFont != NULL) {


### PR DESCRIPTION
設定フォルダダイアログをリサイズできるようにする #1106 の WM_GETDPISCALEDSIZE対応 試作版です。

試作版ですので取り下げさせて頂きます。