### PR TITLE
arm64版でsusieプラグインをサポート #1121

### DIFF
--- a/doc/en/html/about/glossary.html
+++ b/doc/en/html/about/glossary.html
@@ -43,10 +43,14 @@ XMODEM プロトコルをベースにしてるようですが、
     </p>
 
     <p>
-      Tera Term tries to load images using Susie Plug-ins,
-      and using Windows functions such as GDI+, OleLoadPicture(), LoadImage(),
-      and so on.
-      It seems to be possible to load jpg and gif images on Windows 7 or later.
+      Following information was referenced.
+      <ul>
+        <li><a href="https://www.digitalpad.co.jp/~takechin/download.html" target="_blank">Susie NO HEYA / Susie NO download</a><br>
+          PLUG_API.TXT file in <a href="https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh" target="_blank">https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh</a>
+        </li>
+        <li><a href="https://gist.github.com/tapetums/0a924712fb2fa0a7bb93" target="_blank">Susie plugin API definition file</a></li>
+        <li><a href="http://toro.d.dooo.jp/slplugin.html" target="_blank">TORO's Library / TORO's Software library(Win32/Win64 Plugin)</a></li>
+      </ul>
     </p>
   </dd>
 
@@ -87,7 +91,7 @@ On the other hand, when pasted characters is overwritten again to remove the hig
     <li><a href="../usage/tips/vim.html#Bracketed">Vim Control Sequence Examples / Auto indent can be disabled on pasting from clipboard</a>
     <li><a href="../setup/teraterm-misc.html#BracketedSupport">Tera Term setup file / Miscellaneous / Supports bracketed paste</a>
     <li><a href="../setup/teraterm-misc.html#BracketedControlOnly">Tera Term setup file / Miscellaneous / Limit bracketed pasting to cases containing control characters</a>
-      
+
   </ul>
 </dd>
 

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -87,6 +87,10 @@
         Enabled plugin loading settings.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/604" target="_blank">issue #604</a>)
       </li>
+      <li>
+        Susie plugin is now usable with the arm64 version of Tera Term.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1121" target="_blank">issue #1121</a>)
+      </li>
     </ul>
   </li>
 
@@ -117,6 +121,10 @@
       <li>
         Fixed an issue where the Alt+T access key sent the AYT (Are You There) command even when the active TCP/IP connection was not TELNET.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1086" target="_blank">issue #1086</a>)
+      </li>
+      <li>
+        Fixed an issue where Tera Term crashes when using susie plugin.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1121" target="_blank">issue #1121</a>)
       </li>
     </ul>
   </li>

--- a/doc/en/html/menu/setup-additional-theme.html
+++ b/doc/en/html/menu/setup-additional-theme.html
@@ -46,17 +46,32 @@
 
       <dt>Susie Plug-in path:</dt>
       <dd>
-        Path where plugin file is stored.<br>
-        Susie Plug-in is an external file to load various image files
-        using mage viewer software <a href="../about/glossary.html#susie">Susie</a>.<br>
-        Following information was referenced.
-        <ul>
-          <li><a href="https://www.digitalpad.co.jp/~takechin/download.html" target="_blank">Susie NO HEYA / Susie NO download</a><br>
-            PLUG_API.TXT file in <a href="https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh" target="_blank">https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh</a>
-          </li>
-          <li><a href="https://gist.github.com/tapetums/0a924712fb2fa0a7bb93" target="_blank">Susie plugin API definition file</a></li>
-          <li><a href="http://toro.d.dooo.jp/slplugin.html" target="_blank">TORO's Library / TORO's Software library(Win32/Win64 Plugin)</a></li>
-        </ul>
+        Path where <a href="../about/glossary.html#susie">Susie</a> Plug-in files are stored.<br>
+
+        <p>
+          Use Plug-in with same architecture as Tera Term binary.
+          The architecture is determined by the Plug-in's file extension.
+        </p>
+
+        <table border="1">
+          <caption>Plug-in file extension</caption>
+          <tr>
+            <th>architecture</th>
+            <th>extension</th>
+          </tr>
+          <tr>
+            <td>x86 32bit</td>
+            <td>.spi</td>
+          </tr>
+          <tr>
+            <td>x86 64bit</td>
+            <td>.sph</td>
+          </tr>
+          <tr>
+            <td>ARM 64bit</td>
+            <td>.spha</td>
+          </tr>
+        </table>
       </dd>
 
     </dl>

--- a/doc/en/html/menu/setup-additional-visual-theme.html
+++ b/doc/en/html/menu/setup-additional-visual-theme.html
@@ -90,6 +90,13 @@
             bmp, png, gif, jpg etc<br>
             32-bit bmp and transparent png has 8-bit alpha channel.<br>
             Transparent gif file treat one color as transparent.
+
+            <p>
+              Tera Term tries to load images using <a href="../about/glossary.html#susie">Susie</a> Plug-ins,
+              and using Windows functions such as GDI+, OleLoadPicture(), LoadImage(),
+              and so on.
+              It seems to be possible to load jpg and gif images on Windows 7 or later.
+            </p>
           </dd>
 
           <dt>Pattern</dt>

--- a/doc/ja/html/about/glossary.html
+++ b/doc/ja/html/about/glossary.html
@@ -37,10 +37,14 @@ Tera Term の Kermit は今のところ基本的機能しか持っていないので、本家の Kermit に
     </p>
 
     <p>
-      Tera Term は Susie Plug-in を試みたのち、
-      GDI+, OleLoadPicture(), LoadImage() 等の
-      Windows の機能を利用して画像の読み込みを試みます。
-      Windows 7 以降では Windowsの機能で jpg, gif の読み込みが可能のようです。
+      実装時、次の情報を参考にしました。
+      <ul>
+        <li><a href="https://www.digitalpad.co.jp/~takechin/download.html" target="_blank">Susieの部屋 / Susieのだうんろーど</a><br>
+          <a href="https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh" target="_blank">https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh</a> の PLUG_API.TXT
+        </li>
+        <li><a href="https://gist.github.com/tapetums/0a924712fb2fa0a7bb93" target="_blank">Susie プラグイン API 定義ファイル</a></li>
+        <li><a href="http://toro.d.dooo.jp/slplugin.html" target="_blank">TORO's Library / TORO's Software library(Win32/Win64 Plugin)</a></li>
+      </ul>
     </p>
   </dd>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -88,6 +88,10 @@
         プラグインのロード設定を可能とした。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/604" target="_blank">issue #604</a>)
       </li>
+      <li>
+        arm64版Tera Termで、susieプラグインを使用できるようにした。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1121" target="_blank">issue #1121</a>)
+      </li>
     </ul>
   </li>
 
@@ -118,6 +122,10 @@
       <li>
         TELNET 接続中でなくても TCP/IP 接続中なら Alt+T アクセスキーで AYT (Are You There) コマンドが送出される問題を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1086" target="_blank">issue #1086</a>)
+      </li>
+      <li>
+        susieプラグインを使用すると Tera Term がクラッシュする問題を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1121" target="_blank">issue #1121</a>)
       </li>
     </ul>
   </li>

--- a/doc/ja/html/menu/setup-additional-theme.html
+++ b/doc/ja/html/menu/setup-additional-theme.html
@@ -46,19 +46,33 @@
 
       <dt>Susie Plug-in path:</dt>
       <dd>
-        Susie Plug-in ファイルを保存しているパスを指定します。<br>
-        Susie Plug-in は、画像ビュアーソフト <a href="../about/glossary.html#susie">Susie</a>で
-        様々な画像ファイルを読み込むための外部ファイルです。<br>
-        次の情報を参考にしました。
-        <ul>
-          <li><a href="https://www.digitalpad.co.jp/~takechin/download.html" target="_blank">Susieの部屋 / Susieのだうんろーど</a><br>
-            <a href="https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh" target="_blank">https://www.digitalpad.co.jp/~takechin/archives/splug004.lzh</a> の PLUG_API.TXT
-          </li>
-          <li><a href="https://gist.github.com/tapetums/0a924712fb2fa0a7bb93" target="_blank">Susie プラグイン API 定義ファイル</a></li>
-          <li><a href="http://toro.d.dooo.jp/slplugin.html" target="_blank">TORO's Library / TORO's Software library(Win32/Win64 Plugin)</a></li>
-        </ul>
-      </dd>
+        <a href="../about/glossary.html#susie">Susie</a> Plug-in ファイルを保存しているパスを指定します。
 
+        <p>
+          Tera Termのバイナリと同じアーキテクチャのPlug-inを使用します。
+          アーキテクチャはPlug-inの拡張子で判定しています。
+        </p>
+
+        <table border="1">
+          <caption>Plug-in拡張子</caption>
+          <tr>
+            <th>architecture</th>
+            <th>拡張子</th>
+          </tr>
+          <tr>
+            <td>x86 32bit</td>
+            <td>.spi</td>
+          </tr>
+          <tr>
+            <td>x86 64bit</td>
+            <td>.sph</td>
+          </tr>
+          <tr>
+            <td>ARM 64bit</td>
+            <td>.spha</td>
+          </tr>
+        </table>
+      </dd>
     </dl>
 
   </body>

--- a/doc/ja/html/menu/setup-additional-visual-theme.html
+++ b/doc/ja/html/menu/setup-additional-visual-theme.html
@@ -87,6 +87,13 @@
             bmp, png, gif, jpg等<br>
             32bit bmp, 透過pngの場合は8bitのアルファチャンネルが付加されます<br>
             透過gifの場合は1色を透明としてあつかいます。
+
+            <p>
+              Tera Term は <a href="../about/glossary.html#susie">Susie</a> Plug-in を試みたのち、
+              GDI+, OleLoadPicture(), LoadImage() 等の
+              Windows の機能を利用して画像の読み込みを試みます。
+              Windows 7 以降では Windowsの機能で jpg, gif の読み込みが可能のようです。
+            </p>
           </dd>
 
           <dt>パターン</dt>

--- a/teraterm/teraterm/vtdisp.c
+++ b/teraterm/teraterm/vtdisp.c
@@ -464,8 +464,12 @@ static void BGPreloadPicture(BGSrc *src)
 		HANDLE hbuf;
 		BOOL r = SusieLoadPicture(load_file, spi_path, &hbmi, &hbuf);
 		if (r != FALSE) {
-			hbm = CreateBitmapFromBITMAPINFO(hbmi, hbuf);
+			const BITMAPINFO *pbmi = LocalLock(hbmi);
+			const unsigned char *pbuf = LocalLock(hbuf);
+			hbm = CreateBitmapFromBITMAPINFO(pbmi, pbuf);
+			LocalUnlock(hbmi);
 			LocalFree(hbmi);
+			LocalUnlock(hbuf);
 			LocalFree(hbuf);
 		}
 	}


### PR DESCRIPTION
- arm64版の拡張子は ".spha"
- susieプラグインを使用すると、Tera Termがクラッシュする不具合を修正
  - LocalLock() していなかった