### PR TITLE
Fix/#1159 stable_4 vs2022

### DIFF
--- a/teraterm/teraterm/ttermpro.v17.vcxproj
+++ b/teraterm/teraterm/ttermpro.v17.vcxproj
@@ -246,23 +246,23 @@
     <ClInclude Include="vtwin.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ttpfile\ttpfile.v16.vcxproj">
+    <ProjectReference Include="..\ttpfile\ttpfile.v17.vcxproj">
       <Project>{311f2b21-aec4-4384-8209-bb83b54749b4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ttpmacro\ttpmacro.v16.vcxproj">
+    <ProjectReference Include="..\ttpmacro\ttpmacro.v17.vcxproj">
       <Project>{ba519362-a2c2-4b1a-905b-f00791f9038a}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ttpset\ttpset.v16.vcxproj">
+    <ProjectReference Include="..\ttpset\ttpset.v17.vcxproj">
       <Project>{5cf58947-e861-4a5c-b0b1-e85486f149cd}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ttptek\ttptek.v16.vcxproj">
+    <ProjectReference Include="..\ttptek\ttptek.v17.vcxproj">
       <Project>{6d08053b-1c68-4a7e-8766-3553f5af010b}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/teraterm/ttpfile/ttpfile.v17.vcxproj
+++ b/teraterm/ttpfile/ttpfile.v17.vcxproj
@@ -167,7 +167,7 @@
     <None Include="ttpfile.def" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/teraterm/ttpmacro/ttpmacro.v17.vcxproj
+++ b/teraterm/ttpmacro/ttpmacro.v17.vcxproj
@@ -193,7 +193,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/teraterm/ttpset/ttpset.v17.vcxproj
+++ b/teraterm/ttpset/ttpset.v17.vcxproj
@@ -147,7 +147,7 @@
     <ResourceCompile Include="ttpset-version.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/teraterm/ttptek/ttptek.v17.vcxproj
+++ b/teraterm/ttptek/ttptek.v17.vcxproj
@@ -143,7 +143,7 @@
     <ResourceCompile Include="ttptek-version.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ttpcmn\ttpcmn.v16.vcxproj">
+    <ProjectReference Include="..\ttpcmn\ttpcmn.v17.vcxproj">
       <Project>{118e0d32-5553-4f73-9927-e873c1c500e4}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/ttssh2/ttxssh/ttxssh.v17.vcxproj
+++ b/ttssh2/ttxssh/ttxssh.v17.vcxproj
@@ -232,11 +232,11 @@
     <ResourceCompile Include="ttxssh.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\argon2\argon2.v16.vcxproj">
+    <ProjectReference Include="..\argon2\argon2.v17.vcxproj">
       <Project>{d33c59b8-e227-47d2-8f80-eda3e28bf995}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\putty\putty.v16.vcxproj">
+    <ProjectReference Include="..\putty\putty.v17.vcxproj">
       <Project>{98ca1284-8f6c-4791-bf57-7e5fad33744e}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>


### PR DESCRIPTION
Visual Studio 2022 でビルドできないのを修正 #1159