### PR TITLE
Fix/#1217 titleformat doc

### DIFF
--- a/doc/en/html/setup/teraterm-win.html
+++ b/doc/en/html/setup/teraterm-win.html
@@ -249,7 +249,7 @@ Format ID   Title format
 
 <pre>
 Default:
-TitleFormat=5
+TitleFormat=13
 </pre>
 
 

--- a/doc/ja/html/setup/teraterm-win.html
+++ b/doc/ja/html/setup/teraterm-win.html
@@ -265,7 +265,7 @@ Format ID   タイトルの形式
 
 <pre>
 省略時:
-TitleFormat=5
+TitleFormat=13
 </pre>
 
 


### PR DESCRIPTION
ドキュメントの TitleFormat のデフォルト値を修正 #1217