### PR TITLE
TeraTerm Menu でレジストリ使用時、バージョンアップで "LockBoxを使用" が有効になる不具合を修正 #1223

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -6350,7 +6350,7 @@ SYNOPSIS:
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1176" target="_blank">issue #1176</a>)
       </li>
       <li>
-        The issue where "Use LockBox" became enabled after upgrading from versions prior to 1.20 to version 1.20 or later when using the registry has been fixed.
+        The issue where "Use LockBox" might be unintentionally enabled after upgrading from versions prior to 1.20 to version 1.20 or later when using the registry has been fixed.
         This bug was introduced in 1.20.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1223" target="_blank">issue #1223</a>)
       </li>

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -6349,6 +6349,11 @@ SYNOPSIS:
         Fixed a bug where an invalid free() occurred when a filename starting with '"' was entered in the file name box and opening and then closing the file selection dialog.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1176" target="_blank">issue #1176</a>)
       </li>
+      <li>
+        The issue where "Use LockBox" became enabled after upgrading from versions prior to 1.20 to version 1.20 or later when using the registry has been fixed.
+        This bug was introduced in 1.20.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1223" target="_blank">issue #1223</a>)
+      </li>
 </ul>
 
 <h3 id="ttmenu_1.21">2026.02.28 (Ver 1.21)</h3>

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -6350,7 +6350,7 @@ SYNOPSIS:
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1176" target="_blank">issue #1176</a>)
       </li>
       <li>
-        The issue where "Use LockBox" might be unintentionally enabled after upgrading from versions prior to 1.20 to version 1.20 or later when using the registry has been fixed.
+        Fixed an issue where LockBox could be forcibly enabled when loading settings stored in the registry from versions prior to 1.20.
         This bug was introduced in 1.20.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1223" target="_blank">issue #1223</a>)
       </li>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -6358,6 +6358,11 @@
         ファイル名に '"' ではじまる文字が入力された状態で、ファイル選択ダイアログを開いて閉じた時、不正なアドレスを free() する不具合を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1176" target="_blank">issue #1176</a>)
       </li>
+      <li>
+        レジストリ使用時、Ver 1.20 以前から Ver 1.20 以降にバージョンアップした際 "LockBoxを使用" が有効になる不具合を修正した。
+        1.20 からの不具合。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1223" target="_blank">issue #1223</a>)
+      </li>
 </ul>
 
 <h3 id="ttmenu_1.21">2026.02.28 (Ver 1.21)</h3>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -6359,7 +6359,7 @@
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1176" target="_blank">issue #1176</a>)
       </li>
       <li>
-        レジストリ使用時、Ver 1.20 以前から Ver 1.20 以降にバージョンアップした際 "LockBoxを使用" が有効になる場合がある不具合を修正した。
+        Ver 1.20 以前でレジストリに保存された設定を読み込んだとき、強制的に LockBox が使用される場合がある不具合を修正した。
         1.20 からの不具合。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1223" target="_blank">issue #1223</a>)
       </li>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -6359,7 +6359,7 @@
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1176" target="_blank">issue #1176</a>)
       </li>
       <li>
-        レジストリ使用時、Ver 1.20 以前から Ver 1.20 以降にバージョンアップした際 "LockBoxを使用" が有効になる不具合を修正した。
+        レジストリ使用時、Ver 1.20 以前から Ver 1.20 以降にバージョンアップした際 "LockBoxを使用" が有効になる場合がある不具合を修正した。
         1.20 からの不具合。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1223" target="_blank">issue #1223</a>)
       </li>

--- a/ttpmenu/registry.cpp
+++ b/ttpmenu/registry.cpp
@@ -350,11 +350,12 @@ BOOL RegGetStr(HKEY hKey, const wchar_t *lpszValueName, wchar_t *buf, DWORD dwSi
 
 		lError = ::RegQueryValueExW(hKey, lpszValueName, 0, &dwType, (LPBYTE) buf, &dwWriteSize);
 		if (lError != ERROR_SUCCESS) {
+			buf[0] = L'\0';
 			::SetLastError(lError);
 			return FALSE;
 		}
 
-		buf[dwSize - 1] = '\0';
+		buf[dwSize - 1] = L'\0';
 	}
 
 	return TRUE;
@@ -547,6 +548,7 @@ BOOL RegGetBinary(HKEY hKey, const wchar_t *lpszValueName, void *buf, LPDWORD lp
 										&dwType,
 										(LPBYTE) buf,
 										&dwReadSize)) != ERROR_SUCCESS) {
+			memset(buf, 0, *lpdwSize);
 			::SetLastError(lError);
 			return FALSE;
 		}

--- a/ttpmenu/registry.cpp
+++ b/ttpmenu/registry.cpp
@@ -437,6 +437,7 @@ BOOL RegGetDword(HKEY hKey, const wchar_t *lpszValueName, DWORD *dwValue)
 									(LPBYTE) dwValue,
 									&dwSize);
 		if (lError != ERROR_SUCCESS) {
+			*dwValue = 0;
 			::SetLastError(lError);
 			return FALSE;
 		}
@@ -618,4 +619,3 @@ BOOL RegGetBYTE(HKEY hKey, const wchar_t *lpszValueName, BYTE &value)
 	value = (BYTE)d;
 	return r;
 }
-

--- a/ttpmenu/ttpmenu.cpp
+++ b/ttpmenu/ttpmenu.cpp
@@ -1389,9 +1389,7 @@ BOOL RegLoadLoginHostInformation(const wchar_t *szName, JobInfo *job_Info)
 	RegGetStr(hKey, KEY_USERNAME, jobInfo.szUsername, MAX_PATH);
 	RegGetBOOL(hKey, KEY_PASSWDFLAG, jobInfo.bPassword);
 	RegGetBinary(hKey, KEY_PASSWORD, jobInfo.szPassword, &dwSize);
-	if (RegGetBOOL(hKey, KEY_LOCKBOXFLAG, jobInfo.bLockBox) == FALSE) {
-		jobInfo.bLockBox = FALSE;
-	}
+	RegGetBOOL(hKey, KEY_LOCKBOXFLAG, jobInfo.bLockBox);
 
 	RegGetStr(hKey, KEY_TERATERM, jobInfo.szTeraTerm, MAX_PATH);
 	RegGetStr(hKey, KEY_INITFILE, jobInfo.szInitFile, MAX_PATH);

--- a/ttpmenu/ttpmenu.cpp
+++ b/ttpmenu/ttpmenu.cpp
@@ -1389,7 +1389,9 @@ BOOL RegLoadLoginHostInformation(const wchar_t *szName, JobInfo *job_Info)
 	RegGetStr(hKey, KEY_USERNAME, jobInfo.szUsername, MAX_PATH);
 	RegGetBOOL(hKey, KEY_PASSWDFLAG, jobInfo.bPassword);
 	RegGetBinary(hKey, KEY_PASSWORD, jobInfo.szPassword, &dwSize);
-	RegGetBOOL(hKey, KEY_LOCKBOXFLAG, jobInfo.bLockBox);
+	if (RegGetBOOL(hKey, KEY_LOCKBOXFLAG, jobInfo.bLockBox) == FALSE) {
+		jobInfo.bLockBox = FALSE;
+	}
 
 	RegGetStr(hKey, KEY_TERATERM, jobInfo.szTeraTerm, MAX_PATH);
 	RegGetStr(hKey, KEY_INITFILE, jobInfo.szInitFile, MAX_PATH);


### PR DESCRIPTION
#1223 の修正パッチです。