### PR TITLE
cmakeビルド zlibのライブラリファイル名変更 #1226

### DIFF
--- a/libs/lib_zlib.cmake
+++ b/libs/lib_zlib.cmake
@@ -10,9 +10,7 @@ endif()
 set(ZLIB_INCLUDE_DIRS ${ZLIB_ROOT}/include)
 set(ZLIB_LIBRARY_DIRS ${ZLIB_ROOT}/lib)
 if(MINGW)
-  set(ZLIB_LIB
-    ${ZLIB_LIBRARY_DIRS}/libzlibstatic.a
-    )
+  set(ZLIB_LIB ${ZLIB_LIBRARY_DIRS}/libzs.a)
 else()
   if(IS_MULTI_CONFIG)
     set(ZLIB_LIB


### PR DESCRIPTION
- zlib 1.3.2 でファイル名が変更された
- a9b107e976a27d2fa67692b981ab109d06f14b78