### PR TITLE
Setup Directダイアログ、Plugin タブでのファイル名長の上限をなくした #1278

### DIFF
--- a/teraterm/common/win32helper.cpp
+++ b/teraterm/common/win32helper.cpp
@@ -465,3 +465,52 @@ DWORD hGetDlgItemCBTextW(HWND hDlg, int id, int index, wchar_t **text)
 	*text = strW;
 	return NO_ERROR;
 }
+
+/**
+ *	リストビューの文字列取得
+ *
+ *	@param[in]	hDlg		ダイアログ
+ *	@param[in]	id			コントロール(リストビュー)のID
+ *							(0のとき、hDlgをコントロールのハンドルとする)
+ *	@param[in]	item		取得するアイテムのインデックス
+ *	@param[in]	subitem		取得するサブアイテムのインデックス
+ *	@param[out]	text		設定されている文字列
+ *							不要になったらfree()する
+ *	@return	エラーコード,0(=NO_ERROR)のときエラーなし
+ */
+DWORD hGetDlgItemLVTextW(HWND hDlg, int id, int item, int subitem, wchar_t **text)
+{
+	HWND hWnd;
+	if (id == 0) {
+		hWnd = hDlg;
+	} else {
+		hWnd = GetDlgItem(hDlg, id);
+	}
+	assert(hWnd != NULL);
+	size_t buf_len = 64;
+	wchar_t *buf_ptr = NULL;
+
+	for(;;) {
+		wchar_t *p = (wchar_t *)realloc(buf_ptr, sizeof(wchar_t) * buf_len);
+		if (p == NULL) {
+			free(buf_ptr);
+			*text = NULL;
+			return ERROR_NOT_ENOUGH_MEMORY;
+		}
+		buf_ptr = p;
+
+		LV_ITEMW lv_item = {};
+		lv_item.iSubItem = subitem;
+		lv_item.pszText = buf_ptr;
+		lv_item.cchTextMax = (int)buf_len;
+
+		size_t len = (size_t)SendMessageW(hWnd, LVM_GETITEMTEXTW, item, (LPARAM)&lv_item);
+		len += 1;  // +1 = L'\0'
+		if (len < buf_len) {
+			buf_ptr = (wchar_t *)realloc(buf_ptr, sizeof(wchar_t) * len);
+			*text = buf_ptr;
+			return NO_ERROR;
+		}
+		buf_len += 128;
+	}
+}

--- a/teraterm/common/win32helper.h
+++ b/teraterm/common/win32helper.h
@@ -57,6 +57,7 @@ BOOL hSetupDiGetDevicePropertyW(
 	const DEVPROPKEY *PropertyKey,
 	void **buf, size_t *buf_size);
 DWORD hGetDlgItemCBTextW(HWND hDlg, int id, int index, wchar_t **text);
+DWORD hGetDlgItemLVTextW(HWND hDlg, int id, int item, int subitem, wchar_t **text);
 
 #ifdef __cplusplus
 }

--- a/teraterm/teraterm/plugin_pp.cpp
+++ b/teraterm/teraterm/plugin_pp.cpp
@@ -73,26 +73,15 @@ typedef struct {
  */
 static void SetFromListView(HWND hWnd)
 {
-	HWND hWndList = GetDlgItem(hWnd, IDC_SETUP_DIR_LIST);
-	const int list_count = (int)SendMessageW(hWndList, LVM_GETITEMCOUNT, 0, 0);
+	const int list_count = (int)SendDlgItemMessageW(hWnd, IDC_SETUP_DIR_LIST, LVM_GETITEMCOUNT, 0, 0);
 
 	for (int i = 0; i < list_count; i++) {
-		wchar_t filename[MAX_PATH];
-		LV_ITEMW item{};
-		item.mask = LVIF_TEXT;
-		item.iItem = i;
-		item.iSubItem = 0;
-		item.pszText = filename;
-		item.cchTextMax = _countof(filename);
-		SendMessageW(hWndList, LVM_GETITEMW, 0, (LPARAM)&item);
+		wchar_t *filename;
+		hGetDlgItemLVTextW(hWnd, IDC_SETUP_DIR_LIST, i, 0, &filename);
 
-		wchar_t enable_str[32];
-		item.mask = LVIF_TEXT;
-		item.iItem = i;
-		item.iSubItem = 1;
-		item.pszText = enable_str;
-		item.cchTextMax = _countof(enable_str);
-		SendMessageW(hWndList, LVM_GETITEMW, 0, (LPARAM)&item);
+		wchar_t *enable_str;
+		hGetDlgItemLVTextW(hWnd, IDC_SETUP_DIR_LIST, i, 1, &enable_str);
+
 		ExtensionEnable enable =
 			enable_str[0] == L'e' ? EXTENSION_ENABLE :
 			enable_str[0] == L'd' ? EXTENSION_DISABLE : EXTENSION_UNSPECIFIED;
@@ -101,6 +90,9 @@ static void SetFromListView(HWND hWnd)
 		info.filename = filename;
 		info.enable = enable;
 		PluginAddInfo(&info);
+
+		free(filename);
+		free(enable_str);
 	}
 }
 
@@ -159,17 +151,12 @@ static wchar_t *VerifySignature(LPCWSTR pwszSourceFile)
  */
 static void Popup(HWND hWnd, const POINT *pointer_pos, int index)
 {
-	wchar_t enable_str[32];
-	LV_ITEMW item{};
-	item.mask = LVIF_TEXT;
-	item.iItem = index;
-	item.iSubItem = 1;
-	item.pszText = enable_str;
-	item.cchTextMax = _countof(enable_str);
-	SendMessageW(hWnd, LVM_GETITEMW, 0, (LPARAM)&item);
+	wchar_t *enable_str;
+	hGetDlgItemLVTextW(hWnd, 0, index, 1, &enable_str);
 	ExtensionEnable enable =
 		enable_str[0] == L'e' ? EXTENSION_ENABLE :
 		enable_str[0] == L'd' ? EXTENSION_DISABLE : EXTENSION_UNSPECIFIED;
+	free(enable_str);
 
 	HMENU hMenu= CreatePopupMenu();
 	AppendMenuW(hMenu, enable != EXTENSION_ENABLE ? MF_ENABLED : MF_DISABLED | MF_STRING, 1, L"&Enable");
@@ -179,6 +166,7 @@ static void Popup(HWND hWnd, const POINT *pointer_pos, int index)
 	switch (result) {
 	case 1:
 	case 2: {
+		LV_ITEMW item{};
 		item.mask = LVIF_TEXT;
 		item.iItem = index;
 		item.iSubItem = 1;

--- a/teraterm/teraterm/setupdirdlg.cpp
+++ b/teraterm/teraterm/setupdirdlg.cpp
@@ -682,17 +682,10 @@ static INT_PTR CALLBACK OnSetupDirectoryDlgProc(HWND hDlgWnd, UINT msg, WPARAM w
 				ListView_HitTest(nmlist->hdr.hwndFrom, &ht);
 				if (ht.flags & LVHT_ONITEM) {
 					int hit_item = ht.iItem;
-
-					wchar_t path[MAX_PATH];
-					LV_ITEMW item;
-					item.mask = TVIF_TEXT;
-					item.iItem = hit_item;
-					item.iSubItem = 1;
-					item.pszText = path;
-					item.cchTextMax = _countof(path);
-					SendMessageW(nmlist->hdr.hwndFrom, LVM_GETITEMW, 0, (LPARAM)&item);
-
+					wchar_t *path;
+					hGetDlgItemLVTextW(hDlgWnd, IDC_SETUP_DIR_LIST, hit_item, 1, &path);
 					PopupAndExec(nmlist->hdr.hwndFrom, &pointer_pos, path, pts);
+					free(path);
 				}
 				break;
 			}


### PR DESCRIPTION
- リスビューからの文字列取得する hGetDlgItemLVTextW() を追加
  - 文字長制限なし
- setupdirdlg.cpp, plugin_pp.cpp 内のリストビューからの文字取得に使用
  - 変更前はMAX_PATH文字の制限があった