### PR TITLE
ダンプファイル名を実行プログラムごとに分離 #1279

### DIFF
--- a/teraterm/common/ttdebug.cpp
+++ b/teraterm/common/ttdebug.cpp
@@ -31,6 +31,7 @@
 #include <imagehlp.h>
 #include <shlobj.h>	// for SHGetSpecialFolderPathW()
 #include <intrin.h> // for __debugbreak()
+#include <assert.h>
 
 #include "compat_win.h"
 #include "asprintf.h"
@@ -38,6 +39,8 @@
 
 #include "ttdebug.h"
 #include "ttlib.h"
+
+static const wchar_t *BaseName;
 
 /**
  *	コンソールウィンドウを表示するデバグ用
@@ -278,7 +281,8 @@ static wchar_t *CreateDumpFilename()
 	const char *platform = "unknown";
 #endif
 	wchar_t *dump_file;
-	aswprintf(&dump_file, L"teraterm_%hs_%04u%02u%02u-%02u%02u%02u_%hs.dmp",
+	aswprintf(&dump_file, L"%s_%hs_%04u%02u%02u-%02u%02u%02u_%hs.dmp",
+			  BaseName,
 			  platform,
 			  local_time.wYear, local_time.wMonth, local_time.wDay,
 			  local_time.wHour, local_time.wMinute, local_time.wSecond,
@@ -371,9 +375,15 @@ static void InvalidParameterHandler(const wchar_t* /*expression*/,
 
 /**
  *  例外ハンドラのフック
+ *
+ *	例外が発生した時、ミニダンプを出力する
+ *
+ *	@param	basename	ダンプファイルのベース
  */
-void DebugSetException(void)
+void DebugSetException(const wchar_t *basename)
 {
+	assert(basename != NULL);
+	BaseName = basename;
 	SetUnhandledExceptionFilter(ExceptionFilter);
 
 	// Cランタイム無効なパラメータエラーハンドラ

--- a/teraterm/common/ttdebug.h
+++ b/teraterm/common/ttdebug.h
@@ -28,17 +28,11 @@
 
 #include <windows.h>
 
-// 起動時にデバグ用コンソールをオープンする
-// #define DEBUG_OPEN_CONSOLE_AT_STARTUP 1
-
-// 入力コードをダンプする
-// #define DEBUG_DUMP_INPUTCODE 1
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void DebugSetException(void);
+void DebugSetException(const wchar_t *basename);
 HWND DebugConsoleOpen(void);
 void DebugTestCrash(void);
 

--- a/teraterm/teraterm/teraterm.cpp
+++ b/teraterm/teraterm/teraterm.cpp
@@ -64,6 +64,9 @@
 #define new ::new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #endif
 
+// 起動時にデバグ用コンソールをオープンする
+// #define DEBUG_OPEN_CONSOLE_AT_STARTUP 1
+
 static BOOL AddFontFlag;
 static wchar_t *TSpecialFont;
 CVTWindow* pVTWin;
@@ -121,7 +124,7 @@ static void init(void)
 {
 	DLLInit();
 	WinCompatInit();
-	DebugSetException();
+	DebugSetException(L"teraterm");
 	LoadSpecialFont();
 #if defined(DEBUG_OPEN_CONSOLE_AT_STARTUP)
 	DebugConsoleOpen();

--- a/teraterm/teraterm/vtterm.c
+++ b/teraterm/teraterm/vtterm.c
@@ -65,6 +65,7 @@
 #include "vtterm.h"
 #include "tttypes_charset.h"
 
+// 入力コードをダンプする
 // #define DEBUG_DUMP_INPUTCODE 1
 
 #define Accept8BitCtrl ((VTlevel >= 2) && (ts.TermFlag & TF_ACCEPT8BITCTRL))

--- a/teraterm/ttpmacro/ttmacro.cpp
+++ b/teraterm/ttpmacro/ttmacro.cpp
@@ -78,6 +78,8 @@ HWND GetHWND()
 
 static void init()
 {
+	DebugSetException(L"ttpmacro");
+
 	HomeDirW = GetHomeDirW(hInst);
 	SetupFNameW = GetDefaultFNameW(HomeDirW, L"TERATERM.INI");
 
@@ -136,7 +138,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 #ifdef _DEBUG
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
-	DebugSetException();
 
 //	InitCommonControls();
 	init();


### PR DESCRIPTION
- ttpmacro.exe での例外は ttpmacro_*.dmp として出力するようにした
- DebugSetException() にダンプファイルのベース名引数を追加
- ttdebug.h に置かれていたデバグ用 define を移動
  - teraterm.cpp, vtterm.c