### PR TITLE
TTXCopyIniFile.dll INIファイルのパスが255文字を超えるとクラッシュする #1308

### DIFF
--- a/TTXSamples/TTXCopyIniFile/TTXCopyIniFile.c
+++ b/TTXSamples/TTXCopyIniFile/TTXCopyIniFile.c
@@ -13,7 +13,7 @@ static HANDLE hInst; /* Instance handle of TTX*.DLL */
 typedef struct {
 	PReadIniFile origReadIniFile;
 	PWriteIniFile origWriteIniFile;
-	wchar_t origIniFileName[MAXPATHLEN];
+	wchar_t origIniFileName[MAX_PATH];
 } TInstVar;
 
 static TInstVar *pvar;


### PR DESCRIPTION
Windows のパス長に合うよう MAXPATHLEN(256) を MAX_PATH (260) に変更する修正です。