### PR TITLE
Support building on macOS (Homebrew) with mingw toolchain

### DIFF
--- a/libs/buildoniguruma.cmake
+++ b/libs/buildoniguruma.cmake
@@ -94,6 +94,7 @@ if("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
 else()
   # single-configuration
   unset(GENERATE_OPTIONS)
+  list(APPEND GENERATE_OPTIONS "-DARCHITECTURE=${ARCHITECTURE}")
   if(CMAKE_HOST_UNIX)
     list(APPEND GENERATE_OPTIONS "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_LIST_DIR}/../mingw.toolchain.cmake")
   endif(CMAKE_HOST_UNIX)

--- a/libs/buildsfmt.cmake
+++ b/libs/buildsfmt.cmake
@@ -120,6 +120,7 @@ if("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
 else()
   # single-configuration
   unset(GENERATE_OPTIONS)
+  list(APPEND GENERATE_OPTIONS "-DARCHITECTURE=${ARCHITECTURE}")
   if(CMAKE_HOST_UNIX)
     list(APPEND GENERATE_OPTIONS "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_LIST_DIR}/../mingw.toolchain.cmake")
   endif(CMAKE_HOST_UNIX)

--- a/libs/buildzlib.cmake
+++ b/libs/buildzlib.cmake
@@ -81,6 +81,7 @@ if("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
 else()
   # single-configuration
   unset(GENERATE_OPTIONS)
+  list(APPEND GENERATE_OPTIONS "-DARCHITECTURE=${ARCHITECTURE}")
   if(CMAKE_HOST_UNIX)
     list(APPEND GENERATE_OPTIONS "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_LIST_DIR}/../mingw.toolchain.cmake")
   endif(CMAKE_HOST_UNIX)

--- a/mingw.toolchain.cmake
+++ b/mingw.toolchain.cmake
@@ -1,4 +1,4 @@
-﻿# how to build:
+# how to build:
 # mkdir build; cd build
 # cmake .. -G "Unix Makefiles" -DARCHITECTURE=i686 -DCMAKE_TOOLCHAIN_FILE=../mingw.toolchain.cmake
 # cmake .. -G "Unix Makefiles" -DARCHITECTURE=x86_64 -DCMAKE_TOOLCHAIN_FILE=../mingw.toolchain.cmake
@@ -12,6 +12,7 @@ if(NOT DEFINED ARCHITECTURE)
   set(ARCHITECTURE "i686")
 #  set(ARCHITECTURE "x86_64")
 endif()
+message(STATUS "Toolchain: ARCHITECTURE=${ARCHITECTURE}")
 
 # option
 option(USE_CLANG "use clang compiler" OFF)
@@ -28,6 +29,7 @@ elseif(${ARCHITECTURE} STREQUAL "x86_64")
 else()
   message(FATAL_ERROR "ARCHITECTURE=${ARCHITECTURE}")
 endif()
+message(STATUS "Toolchain: PREFIX=${PREFIX}")
 
 set(THREAD_MODEL "-win32")
 #set(THREAD_MODEL "-posix")
@@ -37,16 +39,25 @@ if(MSYS OR (${CMAKE_COMMAND} MATCHES "msys2") OR (${CMAKE_COMMAND} MATCHES "ming
 elseif(CYGWIN OR (${CMAKE_HOST_SYSTEM_NAME} MATCHES "CYGWIN"))
   # Cygwinはposix版のみ
   unset(THREAD_MODEL)
+elseif(APPLE OR (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin"))
+  # macOS (Homebrew) は suffix なし
+  unset(THREAD_MODEL)
 endif()
 
 if(NOT USE_CLANG)
   set(CMAKE_C_COMPILER   ${PREFIX}gcc${THREAD_MODEL})
   set(CMAKE_CXX_COMPILER ${PREFIX}g++${THREAD_MODEL})
   set(CMAKE_RC_COMPILER  ${PREFIX}windres)
+  set(CMAKE_AR           ${PREFIX}gcc-ar${THREAD_MODEL})
+  set(CMAKE_RANLIB       ${PREFIX}gcc-ranlib${THREAD_MODEL})
+  set(CMAKE_NM           ${PREFIX}gcc-nm${THREAD_MODEL})
+  set(CMAKE_OBJCOPY      ${PREFIX}objcopy)
 else()
   set(CMAKE_C_COMPILER   ${PREFIX}clang${THREAD_MODEL})
   set(CMAKE_CXX_COMPILER ${PREFIX}clang++${THREAD_MODEL})
   set(CMAKE_RC_COMPILER  ${PREFIX}windres)
+  set(CMAKE_AR           ${PREFIX}ar)
+  set(CMAKE_RANLIB       ${PREFIX}ranlib)
 endif()
 if(MSYS OR (${CMAKE_COMMAND} MATCHES "msys2") OR (${CMAKE_COMMAND} MATCHES "mingw") OR (${CMAKE_COMMAND} MATCHES "clang64"))
   set(CMAKE_RC_COMPILER windres)


### PR DESCRIPTION
- Add ARCHITECTURE propagation to external library builds (oniguruma, fmt, zlib)
- Add macOS/Darwin host detection in mingw.toolchain.cmake
- Add CMAKE_AR, CMAKE_RANLIB, CMAKE_NM, CMAKE_OBJCOPY definitions for GCC and Clang
- Add diagnostic messages for ARCHITECTURE and PREFIX in toolchain