### PR TITLE
ユーザーごとのインストール時にレジストリの書き込みに失敗していたので修正 #1282

### DIFF
--- a/installer/teraterm.iss
+++ b/installer/teraterm.iss
@@ -60,8 +60,8 @@ AppPublisher=TeraTerm Project
 AppPublisherURL=https://teratermproject.github.io/
 AppSupportURL=https://github.com/TeraTermProject/teraterm/issues
 ; execute
-PrivilegesRequired=admin
-PrivilegesRequiredOverridesAllowed=dialog
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog commandline
 ; during installer execution
 ShowLanguageDialog=yes
 UsePreviousLanguage=no
@@ -204,41 +204,41 @@ Name: {group}\Tera Term; Filename: {app}\ttermpro.exe; WorkingDir: {app}; IconFi
 Name: {group}\{cm:UninstallProgram,{#AppName}}; Filename: {uninstallexe}; Components: TeraTerm; Flags: createonlyiffileexists
 Name: {group}\cyglaunch; Filename: {app}\cyglaunch.exe; WorkingDir: {app}; IconFilename: {app}\cyglaunch.exe; IconIndex: 0; Components: cygterm; Flags: createonlyiffileexists
 Name: {group}\TeraTerm Menu; Filename: {app}\ttpmenu.exe; WorkingDir: {app}; IconFilename: {app}\ttpmenu.exe; IconIndex: 0; Components: TeraTerm_Menu; Flags: createonlyiffileexists
-Name: {userdesktop}\Tera Term 5; Filename: {app}\ttermpro.exe; WorkingDir: {app}; IconFilename: {app}\ttermpro.exe; Components: TeraTerm; Tasks: desktopicon; IconIndex: 0; Flags: createonlyiffileexists
-Name: {userstartup}\TeraTerm Menu; Filename: {app}\ttpmenu.exe; WorkingDir: {app}; IconFilename: {app}\ttpmenu.exe; Components: TeraTerm_Menu; IconIndex: 0; Tasks: startupttmenuicon; Flags: createonlyiffileexists
+Name: {autodesktop}\Tera Term 5; Filename: {app}\ttermpro.exe; WorkingDir: {app}; IconFilename: {app}\ttermpro.exe; Components: TeraTerm; Tasks: desktopicon; IconIndex: 0; Flags: createonlyiffileexists
+Name: {autostartup}\TeraTerm Menu; Filename: {app}\ttpmenu.exe; WorkingDir: {app}; IconFilename: {app}\ttpmenu.exe; Components: TeraTerm_Menu; IconIndex: 0; Tasks: startupttmenuicon; Flags: createonlyiffileexists
 
 [Registry]
 ; Register ProgId
 ;   アンインストール時にはキーごと削除する。
-Root: HKLM; Subkey: Software\Classes\TeraTerm.telnet; ValueType: string; ValueData: "URL: TELNET Protocol"; Flags: uninsdeletekey; Components: TeraTerm; Tasks: telnetassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.telnet; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TeraTerm; Tasks: telnetassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.telnet; ValueName: URL Protocol; ValueType: string; Components: TeraTerm; Tasks: telnetassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.telnet\DefaultIcon; ValueType: string; ValueData: """{app}\ttermpro.exe"",0"; Components: TeraTerm; Tasks: telnetassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.telnet\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /T=1 /nossh /E %1"; Components: TeraTerm; Tasks: telnetassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.ssh; ValueType: string; ValueData: "URL: SSH Protocol"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.ssh; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.ssh; ValueName: URL Protocol; ValueType: string; Components: TTSSH; Tasks: telnetassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.ssh\DefaultIcon; ValueType: string; ValueData: """{app}\ttxssh.dll"",0"; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.ssh\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /ssh %1"; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.MacroFile; ValueType: string; ValueData: "Tera Term Macro File"; Flags: uninsdeletekey; Components: TeraTerm; Tasks: macroassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.MacroFile\DefaultIcon; ValueType: string; ValueData: """{app}\ttpmacro.exe"",3"; Components: TeraTerm; Tasks: macroassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.MacroFile\shell\open\command; ValueType: string; ValueData: """{app}\ttpmacro.exe"" ""%1"""; Components: TeraTerm; Tasks: macroassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.TTYRecordFile; ValueType: string; ValueData: "Tera Term TTY Record File"; Flags: uninsdeletekey; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.TTYRecordFile\DefaultIcon; ValueType: string; ValueData: """{app}\ttermpro.exe"",0"; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
-Root: HKLM; Subkey: Software\Classes\TeraTerm.TTYRecordFile\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /R=""%1"" /TTYPLAY"; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.telnet; ValueType: string; ValueData: "URL: TELNET Protocol"; Flags: uninsdeletekey; Components: TeraTerm; Tasks: telnetassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.telnet; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TeraTerm; Tasks: telnetassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.telnet; ValueName: URL Protocol; ValueType: string; Components: TeraTerm; Tasks: telnetassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.telnet\DefaultIcon; ValueType: string; ValueData: """{app}\ttermpro.exe"",0"; Components: TeraTerm; Tasks: telnetassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.telnet\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /T=1 /nossh /E %1"; Components: TeraTerm; Tasks: telnetassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.ssh; ValueType: string; ValueData: "URL: SSH Protocol"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.ssh; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.ssh; ValueName: URL Protocol; ValueType: string; Components: TTSSH; Tasks: telnetassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.ssh\DefaultIcon; ValueType: string; ValueData: """{app}\ttxssh.dll"",0"; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.ssh\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /ssh %1"; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.MacroFile; ValueType: string; ValueData: "Tera Term Macro File"; Flags: uninsdeletekey; Components: TeraTerm; Tasks: macroassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.MacroFile\DefaultIcon; ValueType: string; ValueData: """{app}\ttpmacro.exe"",3"; Components: TeraTerm; Tasks: macroassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.MacroFile\shell\open\command; ValueType: string; ValueData: """{app}\ttpmacro.exe"" ""%1"""; Components: TeraTerm; Tasks: macroassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.TTYRecordFile; ValueType: string; ValueData: "Tera Term TTY Record File"; Flags: uninsdeletekey; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.TTYRecordFile\DefaultIcon; ValueType: string; ValueData: """{app}\ttermpro.exe"",0"; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
+Root: HKA; Subkey: Software\Classes\TeraTerm.TTYRecordFile\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /R=""%1"" /TTYPLAY"; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
 
 ; Register Application
 ;   Software\RegisteredApplications MUST NOT uninsdeletekey
-Root: HKLM; Subkey: Software\RegisteredApplications; ValueType: string; ValueName: "Tera Term"; ValueData: "Software\Tera Term\Capabilities"; Flags: uninsdeletevalue; Components: TeraTerm; Tasks: telnetassoc sshassoc
+Root: HKA; Subkey: Software\RegisteredApplications; ValueType: string; ValueName: "Tera Term"; ValueData: "Software\Tera Term\Capabilities"; Flags: uninsdeletevalue; Components: TeraTerm; Tasks: telnetassoc sshassoc
 ;   アンインストール時にはキーごと削除する。
-Root: HKLM; Subkey: Software\Tera Term; Flags: uninsdeletekey; Components: TeraTerm; Tasks: telnetassoc sshassoc
-Root: HKLM; Subkey: Software\Tera Term\Capabilities; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "Tera Term"; Components: TeraTerm; Tasks: telnetassoc sshassoc
+Root: HKA; Subkey: Software\Tera Term; Flags: uninsdeletekey; Components: TeraTerm; Tasks: telnetassoc sshassoc
+Root: HKA; Subkey: Software\Tera Term\Capabilities; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "Tera Term"; Components: TeraTerm; Tasks: telnetassoc sshassoc
 
 ; Associate ProgId to Protocol
 ;   プロトコル と 選択できるプログラム の関連付け
-Root: HKLM; Subkey: Software\Tera Term\Capabilities\UrlAssociations; ValueType: string; ValueName: "telnet"; ValueData: "TeraTerm.telnet"; Components: TeraTerm; Tasks: telnetassoc
-Root: HKLM; Subkey: Software\Tera Term\Capabilities\UrlAssociations; ValueType: string; ValueName: "ssh"; ValueData: "TeraTerm.ssh"; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Tera Term\Capabilities\UrlAssociations; ValueType: string; ValueName: "slogin"; ValueData: "TeraTerm.ssh"; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Tera Term\Capabilities\UrlAssociations; ValueType: string; ValueName: "telnet"; ValueData: "TeraTerm.telnet"; Components: TeraTerm; Tasks: telnetassoc
+Root: HKA; Subkey: Software\Tera Term\Capabilities\UrlAssociations; ValueType: string; ValueName: "ssh"; ValueData: "TeraTerm.ssh"; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Tera Term\Capabilities\UrlAssociations; ValueType: string; ValueName: "slogin"; ValueData: "TeraTerm.ssh"; Components: TTSSH; Tasks: sshassoc
 
 ; Legacy Association
 ;   プロトコルにプログラムを直接指定する XP 以前の登録の仕方だが、
@@ -246,37 +246,37 @@ Root: HKLM; Subkey: Software\Tera Term\Capabilities\UrlAssociations; ValueType: 
 ;   HKCR に登録してもプロトコルは出てこない。
 ;   telnet は Windows に元々あるので追加しなくてよい。
 ;   アンインストール時にはプロトコルだけ残す。
-Root: HKLM; Subkey: Software\Classes\ssh; ValueType: string; ValueData: "URL: SSH Protocol"; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\ssh; ValueName: URL Protocol; ValueType: string; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\ssh; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\ssh\DefaultIcon; ValueType: string; ValueData: """{app}\ttxssh.dll"",0"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\ssh\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /ssh %1"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\slogin; ValueType: string; ValueData: "URL: slogin Protocol"; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\slogin; ValueName: URL Protocol; ValueType: string; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\slogin; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\slogin\DefaultIcon; ValueType: string; ValueData: """{app}\ttxssh.dll"",0"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
-Root: HKLM; Subkey: Software\Classes\slogin\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /ssh %1"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\ssh; ValueType: string; ValueData: "URL: SSH Protocol"; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\ssh; ValueName: URL Protocol; ValueType: string; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\ssh; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\ssh\DefaultIcon; ValueType: string; ValueData: """{app}\ttxssh.dll"",0"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\ssh\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /ssh %1"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\slogin; ValueType: string; ValueData: "URL: slogin Protocol"; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\slogin; ValueName: URL Protocol; ValueType: string; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\slogin; ValueName: EditFlags; ValueType: dword; ValueData: 2; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\slogin\DefaultIcon; ValueType: string; ValueData: """{app}\ttxssh.dll"",0"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
+Root: HKA; Subkey: Software\Classes\slogin\shell\open\command; ValueType: string; ValueData: """{app}\ttermpro.exe"" /ssh %1"; Flags: uninsdeletekey; Components: TTSSH; Tasks: sshassoc
 ;   拡張子 と プログラム の関連付け
 ;   この拡張子がほかのプログラムとバッティングすることはないと思われるので、RegisteredApplications への登録はしない。
 ;   Inno Setup のサンプルでも Classes\.ext に直接書き込んでいる（Examples\Example3.iss）。
 ;   アンインストール時 .ext は残す。
-Root: HKLM; Subkey: Software\Classes\.ttl\OpenWithProgids; ValueType: string; ValueName: "TeraTerm.MacroFile"; Flags: uninsdeletevalue; Components: TeraTerm; Tasks: macroassoc
-Root: HKLM; Subkey: Software\Classes\.tty\OpenWithProgids; ValueType: string; ValueName: "TeraTerm.TTYRecordFile"; Flags: uninsdeletevalue; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
+Root: HKA; Subkey: Software\Classes\.ttl\OpenWithProgids; ValueType: string; ValueName: "TeraTerm.MacroFile"; Flags: uninsdeletevalue; Components: TeraTerm; Tasks: macroassoc
+Root: HKA; Subkey: Software\Classes\.tty\OpenWithProgids; ValueType: string; ValueName: "TeraTerm.TTYRecordFile"; Flags: uninsdeletevalue; Components: Additional_Plugins/TTXttyrec; Tasks: ttyplayassoc
 
 ; Cygterm Here
-Root: HKCU; Subkey: Software\Classes\Folder\shell\cygterm; Flags: uninsdeletekey; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\Folder\shell\cygterm; ValueType: string; ValueData: Cy&gterm Here; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\Folder\shell\cygterm; ValueType: string; ValueName: Icon; ValueData: """{app}\cyglaunch.exe"""; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\Folder\shell\cygterm\command; ValueType: string; ValueData: """{app}\cyglaunch.exe"" -nocd -v CHERE_INVOKING=y -d ""\""%L\"""""; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Folder\shell\cygterm; Flags: uninsdeletekey; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Folder\shell\cygterm; ValueType: string; ValueData: Cy&gterm Here; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Folder\shell\cygterm; ValueType: string; ValueName: Icon; ValueData: """{app}\cyglaunch.exe"""; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Folder\shell\cygterm\command; ValueType: string; ValueData: """{app}\cyglaunch.exe"" -nocd -v CHERE_INVOKING=y -d ""\""%L\"""""; Components: cygterm; Tasks: cygtermhere
 ; Cygterm Here from folder Background
-Root: HKCU; Subkey: Software\Classes\Directory\Background\shell\cygterm; Flags: uninsdeletekey; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\Directory\Background\shell\cygterm; ValueType: string; ValueData: Cy&gterm Here; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\Directory\Background\shell\cygterm; ValueType: string; ValueName: Icon; ValueData: """{app}\cyglaunch.exe"""; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\Directory\Background\shell\cygterm\command; ValueType: string; ValueData: """{app}\cyglaunch.exe"" -nocd -v CHERE_INVOKING=y -d ""\""%V\"""""; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm; Flags: uninsdeletekey; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm; ValueType: string; ValueData: Cy&gterm Here; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm; ValueType: string; ValueName: Icon; ValueData: """{app}\cyglaunch.exe"""; Components: cygterm; Tasks: cygtermhere
-Root: HKCU; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm\command; ValueType: string; ValueData: """{app}\cyglaunch.exe"" -nocd -v CHERE_INVOKING=y -d ""\""%V\"""""; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Directory\Background\shell\cygterm; Flags: uninsdeletekey; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Directory\Background\shell\cygterm; ValueType: string; ValueData: Cy&gterm Here; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Directory\Background\shell\cygterm; ValueType: string; ValueName: Icon; ValueData: """{app}\cyglaunch.exe"""; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\Directory\Background\shell\cygterm\command; ValueType: string; ValueData: """{app}\cyglaunch.exe"" -nocd -v CHERE_INVOKING=y -d ""\""%V\"""""; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm; Flags: uninsdeletekey; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm; ValueType: string; ValueData: Cy&gterm Here; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm; ValueType: string; ValueName: Icon; ValueData: """{app}\cyglaunch.exe"""; Components: cygterm; Tasks: cygtermhere
+Root: HKA; Subkey: Software\Classes\LibraryFolder\Background\shell\cygterm\command; ValueType: string; ValueData: """{app}\cyglaunch.exe"" -nocd -v CHERE_INVOKING=y -d ""\""%V\"""""; Components: cygterm; Tasks: cygtermhere
 
 [Tasks]
 Name: desktopicon; Description: {cm:task_desktopicon}; Components: TeraTerm


### PR DESCRIPTION
- ユーザーごとなので、HKLM ではなく、 HKCU へ書き込む
- スクリプト上は HKA とすると、自動的に HKLM または HKCU となる
  - HKLM を HKA に変更
  - HKCU も HKA に変更
- 同様に次の修正も行った
  - {userdesktop} を {autodesktop} に変更
  - {userstartup} を {autostartup} に変更
- {group} は {autoprograms}\Tera Term 5 となる
  - {autoprograms} + DefaultGroupName
- PrivilegesRequired=admin から lowest に変更
  - 全ユーザー向け/ユーザーごとインストール向けに修正
- PrivilegesRequiredOverridesAllowed に commandline 追加
  - 引数 /allusers /currentuser で指定可能となる