### PR TITLE
TERATERM.INIを保存するだけで、設定がフルパスとなるのを修正 #1310

### DIFF
--- a/teraterm/common/ttlib.h
+++ b/teraterm/common/ttlib.h
@@ -213,6 +213,7 @@ void SetDPIAwareness(const wchar_t *SetupFNameW);
 wchar_t *GetFullPathW(const wchar_t *dir, const wchar_t *rel_path);
 char *GetVersionSubstr(void);
 DWORD TTCreateProcess(const wchar_t *cmd, const wchar_t *arg1, const wchar_t *arg2);
+wchar_t* ResolveAbsolutePath(const wchar_t* user_path, const wchar_t* base_dir);
 
 #ifdef __cplusplus
 }

--- a/teraterm/common/ttlib_static_cpp.cpp
+++ b/teraterm/common/ttlib_static_cpp.cpp
@@ -2097,3 +2097,38 @@ DWORD TTCreateProcess(const wchar_t *cmd, const wchar_t *arg1, const wchar_t *ar
 	}
 	return e;
 }
+
+/**
+ *	ユーザーパスを絶対パスに変換する
+ *
+ *	変換されたパスが実在するかのチェックは別途行うこと
+ *
+ *	@param[in]	user_path	ユーザー指定パス（相対 or 絶対）
+ *	@param[in]	base_dir	相対パスの場合に使用するベースディレクトリ
+ *							絶対パスではないとき、
+ *							カレントディレクトリをベースにする
+ *	@return		正規化済み絶対パス
+ *				不要になったら free() すること
+ *				失敗時はNULL。
+ */
+wchar_t* ResolveAbsolutePath(const wchar_t* user_path, const wchar_t* base_dir)
+{
+	if (!user_path || !base_dir) return NULL;
+
+	wchar_t *combined;
+
+	if (IsRelativePathW(user_path)) {
+		// 相対パス, base_dir と結合
+		aswprintf(&combined, L"%s\\%s", base_dir, user_path);
+	} else {
+		// 絶対パスはそのまま使う
+		combined = _wcsdup(user_path);
+	}
+
+	// 正規化
+	wchar_t *full;
+	hGetFullPathNameW(combined, &full, NULL);
+	free(combined);
+
+	return full;
+}

--- a/teraterm/teraterm/themedlg.cpp
+++ b/teraterm/teraterm/themedlg.cpp
@@ -58,6 +58,7 @@
 #include "vtdisp.h"
 #include "tmfc.h"
 #include "tmfc_propdlg.h"
+#include "inifile_com.h"
 
 #include "theme.h"
 #include "themedlg_res.h"
@@ -884,27 +885,31 @@ static INT_PTR CALLBACK FileProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 		case IDC_FILE_LOAD_BUTTON | (BN_CLICKED << 16): {
 			// load
 			// テーマファイル読み込み
-			OPENFILENAMEW ofn = {};
-			wchar_t theme_file[MAX_PATH];
+			wchar_t *theme_file = NULL;
+			wchar_t *initial_dir = NULL;
 
 			if (ts->EtermLookfeel.BGThemeFileW != NULL) {
-				wcscpy_s(theme_file, _countof(theme_file), ts->EtermLookfeel.BGThemeFileW);
+				theme_file =
+					ResolveAbsolutePath(ts->EtermLookfeel.BGThemeFileW,
+										ts->HomeDirW);
 			}
 			else {
-				theme_file[0] = 0;
+				initial_dir = _wcsdup(ts->HomeDirW);
 			}
 
-			ofn.lStructSize = get_OPENFILENAME_SIZEW();
+			TTOPENFILENAMEW ofn = {};
 			ofn.hwndOwner   = hWnd;
 			ofn.lpstrFile   = theme_file;
-			ofn.nMaxFile    = _countof(theme_file);
+			ofn.lpstrInitialDir = initial_dir;
 			ofn.nFilterIndex = 1;
 			ofn.hInstance = dlg_data->hInst;
 			ofn.lpstrDefExt = L"ini";
 			ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY;
 			ofn.lpstrTitle = L"select theme file";
 
-			if (GetOpenFileNameW(&ofn)) {
+			if (TTGetOpenFileNameW(&ofn, &theme_file)) {
+				free(ts->EtermLookfeel.BGThemeFileW);
+				ts->EtermLookfeel.BGThemeFileW = theme_file;
 				ThemeLoad(theme_file, &dlg_data->BGTab.bg_theme, &dlg_data->ColorTab.color_theme);
 
 				static const TTMessageBoxInfoW info = {
@@ -927,15 +932,11 @@ static INT_PTR CALLBACK FileProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 		case IDC_FILE_SAVE_BUTTON | (BN_CLICKED << 16): {
 			// save
 			// テーマファイル書き出し
-			wchar_t theme_file[MAX_PATH];
-			OPENFILENAMEW ofn = {};
+			wchar_t *theme_file = ts->EtermLookfeel.BGThemeFileW;
+			TTOPENFILENAMEW ofn = {};
 
-			theme_file[0] = 0;
-
-			ofn.lStructSize = get_OPENFILENAME_SIZEW();
 			ofn.hwndOwner   = hWnd;
 			ofn.lpstrFile   = theme_file;
-			ofn.nMaxFile    = _countof(theme_file);
 			//ofn.lpstrFilter = "";
 			ofn.nFilterIndex = 1;
 			ofn.hInstance = dlg_data->hInst;
@@ -943,8 +944,11 @@ static INT_PTR CALLBACK FileProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
 			ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY;
 			ofn.lpstrTitle = L"save theme file";
 
-			if (GetSaveFileNameW(&ofn)) {
+			if (TTGetSaveFileNameW(&ofn, &theme_file)) {
+				free(ts->EtermLookfeel.BGThemeFileW);
+				ts->EtermLookfeel.BGThemeFileW = theme_file;
 				LRESULT checked = SendDlgItemMessageA(hWnd, IDC_FILE_SAVE_BG_CHECK, BM_GETCHECK, 0, 0);
+				WriteIniBom(theme_file, FALSE);
 				if (checked & BST_CHECKED) {
 					ThemeSaveBG(&dlg_data->BGTab.bg_theme, theme_file);
 				}

--- a/teraterm/teraterm/vtdisp.c
+++ b/teraterm/teraterm/vtdisp.c
@@ -102,6 +102,7 @@ typedef struct vtdraw {
 	 */
 	COLORREF ANSIColor[256];
 
+	const TTTSet *pts;
 } vtdraw_t;
 
 int WinWidth, WinHeight;		// 画面に表示されている文字数(セル数)
@@ -354,10 +355,19 @@ static BOOL WINAPI AlphaBlendWithoutAPI(HDC hdcDest,int dx,int dy,int width,int 
 }
 
 // 画像読み込み関係
-static void BGPreloadPicture(BGSrc *src)
+static void BGPreloadPicture(BGSrc *src, const TTTSet *pts)
 {
+	wchar_t *susie_path = pts == NULL ? NULL :
+		ResolveAbsolutePath(ts.EtermLookfeel.BGSPIPathW, pts->HomeDirW);
+
 	BitmapLoadParam_t param = {};
-	param.SusiePluginPath = ts.EtermLookfeel.BGSPIPathW;
+	if (susie_path == NULL || susie_path[0] == 0) {
+		// 未設定
+		param.SusiePluginPath = NULL;
+	} else {
+		param.SusiePluginPath = susie_path;
+	}
+
 	HBITMAP hbm = NULL;
 	const wchar_t *load_file = src->fileW;
 	BitmapLoad(load_file, &param, &hbm);
@@ -373,6 +383,8 @@ static void BGPreloadPicture(BGSrc *src)
 	}else{
 		src->type = BG_COLOR;
 	}
+
+	free(susie_path);
 }
 
 static void BGGetWallpaperInfo(WallpaperInfo *wi)
@@ -616,7 +628,7 @@ load_finish:
 	src->color = GetSysColor(COLOR_DESKTOP);
 }
 
-static void BGPreloadSrc(BGSrc *src)
+static void BGPreloadSrc(BGSrc *src, const TTTSet *pts)
 {
 	if (!src->enable) {
 		return;
@@ -633,7 +645,7 @@ static void BGPreloadSrc(BGSrc *src)
 			break;
 
 		case BG_PICTURE:
-			BGPreloadPicture(src);
+			BGPreloadPicture(src, pts);
 			break;
 
 		default:
@@ -1069,9 +1081,9 @@ void BGSetupPrimary(vtdraw_t *vt, BOOL forceSetup)
   CopyRect(&BGPrevRect,&rect);
 
   //壁紙 or 背景をプリロード
-  BGPreloadSrc(&BGDest);
-  BGPreloadSrc(&BGSrc1);
-  BGPreloadSrc(&BGSrc2);
+  BGPreloadSrc(&BGDest, vt->pts);
+  BGPreloadSrc(&BGSrc1, vt->pts);
+  BGPreloadSrc(&BGSrc2, vt->pts);
 
   _OutputDebugPrintf("BGSetupPrimary : BGInSizeMove = %d\n",BGInSizeMove);
 
@@ -1201,15 +1213,19 @@ void BGLoadThemeFile(vtdraw_t *vt, const TTTSet *pts)
 		BGReadIniFile(vt, NULL);
 		BGEnable = FALSE;
 		break;
-	case 1:
-		if (pts->EtermLookfeel.BGThemeFileW != NULL) {
-			// テーマファイルの指定がある
-			BGReadIniFile(vt, pts->EtermLookfeel.BGThemeFileW);
-			BGEnable = TRUE;
+	case 1: {
+		// テーマファイルの指定がある
+		BGEnable = FALSE;
+		const wchar_t *theme_file = pts->EtermLookfeel.BGThemeFileW;
+		if (theme_file != NULL) {
+			wchar_t *full_path = ResolveAbsolutePath(theme_file, pts->HomeDirW);
+			if (GetFileAttributesW(full_path) != INVALID_FILE_ATTRIBUTES) {
+				BGReadIniFile(vt, full_path);
+				BGEnable = TRUE;
+			}
+			free(full_path);
 		}
-		else {
-			BGEnable = FALSE;
-		}
+	}
 		break;
 	case 2: {
 		// ランダムテーマ (or テーマファイルを指定がない)
@@ -1463,12 +1479,13 @@ static void DispSetNearestColors(int start, int end, HDC DispCtx)
  *	@retval	vtdraw_t	描画先情報(ハンドル)
  *						EndiDisp() で開放する
  */
-vtdraw_t *InitDisp(HWND hVTWin)
+vtdraw_t *InitDisp(HWND hVTWin, const TTTSet *pts)
 {
 	vtdraw_t *vt = (vtdraw_t *)calloc(1, sizeof(*vt));
 	HDC TmpDC;
 	BOOL bMultiDisplaySupport = FALSE;
 	vtdisp_work_t *w = &vtdisp_work;
+	vt->pts = pts;
 
 	TmpDC = GetDC(NULL);
 

--- a/teraterm/teraterm/vtdisp.h
+++ b/teraterm/teraterm/vtdisp.h
@@ -80,7 +80,7 @@ void BGOnSettingChange(vtdraw_t *vt);
 void BGOnEnterSizeMove(void);
 void BGOnExitSizeMove(vtdraw_t *vt);
 
-vtdraw_t *InitDisp(HWND hVTWin);
+vtdraw_t *InitDisp(HWND hVTWin, const TTTSet *pts);
 void EndDisp(vtdraw_t *vt);
 void DispReset(vtdraw_t *vt);
 void DispConvWinToScreen(vtdraw_t *vt, int Xw, int Yw, int *Xs, int *Ys, PBOOL Right);

--- a/teraterm/teraterm/vtwin.cpp
+++ b/teraterm/teraterm/vtwin.cpp
@@ -715,7 +715,7 @@ CVTWindow::CVTWindow(HINSTANCE hInstance)
 	HVTWin = GetSafeHwnd();
 	if (HVTWin == NULL) return;
 	cv.HWin = HVTWin;
-	vt_src = InitDisp(HVTWin);
+	vt_src = InitDisp(HVTWin, &ts);
 	BGLoadThemeFile(vt_src, &ts);
 
 	// Windows 11 でウィンドウの角が丸くならないようにする

--- a/teraterm/ttpset/ttset.c
+++ b/teraterm/ttpset/ttset.c
@@ -486,38 +486,12 @@ static void DispReadIni(const wchar_t *FName, PTTSet ts)
 	if (ts->EtermLookfeel.BGSPIPathW != NULL) {
 		free(ts->EtermLookfeel.BGSPIPathW);
 	}
-	hGetPrivateProfileStringW(BG_SECTIONW, L"BGSPIPath", L"plugin", FName, &base);
-	if (base[0] == 0) {
-		free(base);
-		ts->EtermLookfeel.BGSPIPathW = NULL;
-	}
-	else {
-		wchar_t *full;
-		if (IsRelativePathW(base)) {
-			aswprintf(&full, L"%s\\%s", ts->HomeDirW, base);
-			ts->EtermLookfeel.BGSPIPathW = full;
-			free(base);
-		}
-		else {
-			ts->EtermLookfeel.BGSPIPathW = base;
-		}
-	}
-	hGetPrivateProfileStringW(BG_SECTIONW, L"BGThemeFile", L"", FName, &base);
-	if (base[0] == 0) {
-		free(base);
-		ts->EtermLookfeel.BGThemeFileW = NULL;
-	}
-	else {
-		if (IsRelativePathW(base)) {
-			wchar_t *full;
-			aswprintf(&full, L"%s\\%s", ts->HomeDirW, base);
-			ts->EtermLookfeel.BGThemeFileW = full;
-			free(base);
-		}
-		else {
-			ts->EtermLookfeel.BGThemeFileW = base;
-		}
-	}
+	free(ts->EtermLookfeel.BGSPIPathW);
+	hGetPrivateProfileStringW(BG_SECTIONW, L"BGSPIPath", L"plugin", FName,
+							  &ts->EtermLookfeel.BGSPIPathW);
+	free(ts->EtermLookfeel.BGThemeFileW);
+	hGetPrivateProfileStringW(BG_SECTIONW, L"BGThemeFile", L"", FName,
+							  &ts->EtermLookfeel.BGThemeFileW);
 }
 
 /**


### PR DESCRIPTION
- 次の設定
  - BGSPIPath
  - BGThemeFile
- iniから読んだ直後にフルパスにしていた
- フルパスでなくても動作するよう修正