### PR TITLE
TERATERM.INI を読み込んだ時、double free する場合があったので修正 #1310

### DIFF
--- a/teraterm/ttpset/ttset.c
+++ b/teraterm/ttpset/ttset.c
@@ -483,9 +483,6 @@ static void DispReadIni(const wchar_t *FName, PTTSet ts)
 	ts->EtermLookfeel.BGNoFrame = GetOnOff(BG_SECTION, "BGNoFrame", FName, FALSE);
 	ts->EtermLookfeel.BGFastSizeMove = GetOnOff(BG_SECTION, "BGFastSizeMove", FName, TRUE);
 	ts->EtermLookfeel.BGNoCopyBits = GetOnOff(BG_SECTION, "BGFlickerlessMove", FName, TRUE);
-	if (ts->EtermLookfeel.BGSPIPathW != NULL) {
-		free(ts->EtermLookfeel.BGSPIPathW);
-	}
 	free(ts->EtermLookfeel.BGSPIPathW);
 	hGetPrivateProfileStringW(BG_SECTIONW, L"BGSPIPath", L"plugin", FName,
 							  &ts->EtermLookfeel.BGSPIPathW);


### PR DESCRIPTION
- 起動後、設定読み込みを行った際に double free となる