### PR TITLE
/PIPE オプション指定時にクラッシュする場合があった #1318

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -93,6 +93,11 @@
         This bug was introduced in 5.4.0.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1277" target="_blank">issue #1277</a>)
       </li>
+      <li>
+        Fixed an issue where ttermpro.exe crashes when "pipe_name" or "server\pipe_name" is specified with the /PIPE command line option.
+        This bug was introduced in 5.0.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1318" target="_blank">issue #1318</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -93,6 +93,11 @@
         5.4.0 からの不具合。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1277" target="_blank">issue #1277</a>)
       </li>
+      <li>
+        /PIPE コマンドラインオプションに "pipe_name" 又は "server\pipe_name" の形式を指定するとクラッシュする問題を修正した。
+        5.0 からの不具合。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1318" target="_blank">issue #1318</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/ttpset/ttset.c
+++ b/teraterm/ttpset/ttset.c
@@ -3868,7 +3868,9 @@ void PASCAL _ParseParam(wchar_t *Param, PTTSet ts, PCHAR DDETopic)
 			ParamTCP = ParsePortNameW(&Temp[3]);
 		}
 		else if (_wcsicmp(Temp, L"/PIPE") == 0 ||
-		         _wcsicmp(Temp, L"/NAMEDPIPE") == 0) {	/* 名前付きパイプ */
+		         _wcsicmp(Temp, L"/NAMEDPIPE") == 0) {
+			// 名前付きパイプ
+			//		互換性のため "/NAMEDPIPE" は残してある
 			ParamPort = IdNamedPipe;
 		}
 		else if (_wcsnicmp(Temp, L"/R=", 3) == 0) {	/* Replay filename */
@@ -3994,8 +3996,8 @@ void PASCAL _ParseParam(wchar_t *Param, PTTSet ts, PCHAR DDETopic)
 		break;
 	case IdNamedPipe:
 		if (ts->HostName[0] != 0 && ts->HostName[0] != '\\') {
-			char * p = strchr(ts->HostName, '\\');
-			if (p == NULL) {
+			char *p = strchr(ts->HostName, '\\');
+			if (p != NULL) {
 				*p++ = '\0';
 				_snwprintf_s(Temp, _countof(Temp), _TRUNCATE, L"\\\\%hs\\pipe\\%hs", ts->HostName, p);
 			}


### PR DESCRIPTION
- 次の指定の時クラッシュ
  - "pipe_name"
  - "server\pipe_name"
- 次の場合はクラッシュしない
  - "\\.\server\pipe\pipe_name"
- Tera Term 5.0 からの不具合
- #1313 の指摘で発見