### PR TITLE
コンパイル時の警告を修正 #1327

### DIFF
--- a/teraterm/common/CMakeLists.txt
+++ b/teraterm/common/CMakeLists.txt
@@ -86,6 +86,10 @@ add_library(
   win32helper.h
 )
 
+if(MSVC)
+  target_compile_options(${PROJECT_NAME} PRIVATE /W4)
+endif(MSVC)
+
 target_include_directories(
   ${PROJECT_NAME}
   PUBLIC

--- a/teraterm/common/ttcommdlg.cpp
+++ b/teraterm/common/ttcommdlg.cpp
@@ -127,7 +127,6 @@ static BOOL TTSHBrowseForFolderWAPI(const TTBROWSEINFOW *bi, const wchar_t *def,
 	else
 #endif
 	{
-		wchar_t buf[MAX_PATH];
 		if (!SHGetPathFromIDListW(pidl, buf)) {
 			return FALSE;
 		}

--- a/teraterm/teraterm/unicode.cpp
+++ b/teraterm/teraterm/unicode.cpp
@@ -900,10 +900,10 @@ void OverrideCharWidthInfoGet(const wchar_t *fname, OverrideCharWidthInfo *info)
 		int r = swscanf(list, L"%[^,] , %s", ini, section, (unsigned int)len);
 #endif
 		if (r != 2) {
-			int r = swscanf_s(list, L"%s", section, (unsigned int)len);
+			r = swscanf_s(list, L"%s", section, (unsigned int)len);
 			if (r == 1) {
 				free(ini);
-				ini = wcsdup(fname);
+				ini = _wcsdup(fname);
 			} else {
 				r = 0;
 			}
@@ -933,7 +933,7 @@ void OverrideCharWidthInfoGet(const wchar_t *fname, OverrideCharWidthInfo *info)
 				if (name != NULL && name[0] != L'\0') {
 					p->name = name;
 				} else {
-					p->name = wcsdup(p->section);
+					p->name = _wcsdup(p->section);
 					free(name);
 				}
 			}

--- a/teraterm/teraterm/vtterm.c
+++ b/teraterm/teraterm/vtterm.c
@@ -514,7 +514,7 @@ static BOOL NeedsOutputBufs(void)
 	return FLogIsOpendText() || DDELog;
 }
 
-void MoveToStatusLine()
+static void MoveToStatusLine()
 {
 	MainX = CursorX;
 	MainY = CursorY;
@@ -5545,7 +5545,8 @@ static BOOL DecLocatorReport(int Event, int Button)
 #define MOUSE_POS_LIMIT (255 - 32)
 #define MOUSE_POS_EXT_LIMIT (2047 - 32)
 
-int MakeMouseReportStr(char *buff, size_t buffsize, int mb, int x, int y) {
+static int MakeMouseReportStr(char *buff, size_t buffsize, int mb, int x, int y)
+{
 	char tmpx[3], tmpy[3];
 
 	switch (MouseReportExtMode) {

--- a/teraterm/ttpcmn/language.c
+++ b/teraterm/ttpcmn/language.c
@@ -90,6 +90,9 @@ DllExport BYTE PASCAL RussConv(int cin, int cout, BYTE b)
 #if 0
 	return CodeConvRussConv(cin, cout, b);
 #else
+	(void)cin;
+	(void)cout;
+	(void)b;
 	return 0;
 #endif
 }

--- a/teraterm/ttpset/ttset.c
+++ b/teraterm/ttpset/ttset.c
@@ -477,7 +477,6 @@ static void ReadFont3(
  */
 static void DispReadIni(const wchar_t *FName, PTTSet ts)
 {
-	wchar_t *base;
 	ts->EtermLookfeel.BGEnable = GetPrivateProfileInt(BG_SECTION, "BGEnable", 0, FName);
 	ts->EtermLookfeel.BGUseAlphaBlendAPI = GetOnOff(BG_SECTION, "BGUseAlphaBlendAPI", FName, TRUE);
 	ts->EtermLookfeel.BGNoFrame = GetOnOff(BG_SECTION, "BGNoFrame", FName, FALSE);


### PR DESCRIPTION
- teraterm/common cmakeビルド時に /W4 オプションを追加
- wcsdup() -> _wcsdup()
  - warning C4996: 'wcsdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _wcsdup. See online help for details.
- teraterm/vtterm.c
  - MoveToStatusLine()にstaticを追加
- ttpcmn/language.c
  - RussConv()の未使用引き数警告対策
  - warning C4100: 'b': 参照されないパラメーター
- common/ttcommdlg.cpp
  - warning C4456: 'r' を宣言すると、以前のローカル宣言が隠蔽されます
- ttpset/ttset.c
  - warning C4101: 'base': ローカル変数は 1 度も使われていません。