### PR TITLE
ビルド失敗時に GitHub Actions がエラーで止まるようにする

### DIFF
--- a/installer/create_package.bat
+++ b/installer/create_package.bat
@@ -32,6 +32,11 @@ if "%RELEASE%" == "1" (
 rem ポータブル版をコピーして取っておく(署名に使用する)
 %CMAKE% -E rm -rf Output/portable/teraterm-%arch%
 %CMAKE% -E copy_directory Output/build/teraterm-%arch% Output/portable/teraterm-%arch%
+if ERRORLEVEL 1 (
+    echo ERROR copy_directory Output/build/teraterm-%arch%
+    endlocal
+    exit /b 1
+)
 
 
 rem (署名なし)インストーラ作成
@@ -45,21 +50,63 @@ set INNO_SETUP_ARCH="/DArch=x86"
 if "%arch%" == "x64" (set INNO_SETUP_ARCH=/DArch=%arch%)
 if "%arch%" == "arm64" (set INNO_SETUP_ARCH=/DArch=%arch%)
 %INNO_SETUP% %INNO_SETUP_APPVERSION% /OOutput %INNO_SETUP_OUTPUT% /DSrcDir=Output\build\teraterm-%arch% %INNO_SETUP_ARCH% teraterm.iss
+if ERRORLEVEL 1 (
+    echo ERROR %INNO_SETUP%
+    endlocal
+    exit /b 1
+)
 
 rem (署名なし)ポータブル版のzipを作成
 pushd Output
 %CMAKE% -E rm -rf %OUTPUT%
 %CMAKE% -E rm -rf %OUTPUT%_pdb
 %CMAKE% -E copy_directory build\teraterm-%arch% %OUTPUT%
+if ERRORLEVEL 1 (
+    echo ERROR copy_directory build\teraterm-%arch%
+    popd
+    endlocal
+    exit /b 1
+)
 %CMAKE% -E copy_directory build\teraterm-%arch%_pdb %OUTPUT%_pdb
+if ERRORLEVEL 1 (
+    echo ERROR copy_directory build\teraterm-%arch%_pdb
+    popd
+    endlocal
+    exit /b 1
+)
 %CMAKE% -E tar cf %OUTPUT%.zip --format=zip %OUTPUT%/
+if ERRORLEVEL 1 (
+    echo ERROR tar %OUTPUT%.zip
+    popd
+    endlocal
+    exit /b 1
+)
 %CMAKE% -E tar cf %OUTPUT%_pdb.zip --format=zip %OUTPUT%_pdb/
+if ERRORLEVEL 1 (
+    echo ERROR tar %OUTPUT%_pdb.zip
+    popd
+    endlocal
+    exit /b 1
+)
 popd
 
 rem ハッシュを作成
 pushd Output
 %CMAKE% -E sha256sum %OUTPUT%.exe %OUTPUT%.zip %OUTPUT%_pdb.zip > %OUTPUT%.sha256sum
+if ERRORLEVEL 1 (
+    echo ERROR sha256sum
+    popd
+    endlocal
+    exit /b 1
+)
 %CMAKE% -E sha512sum %OUTPUT%.exe %OUTPUT%.zip %OUTPUT%_pdb.zip > %OUTPUT%.sha512sum
+if ERRORLEVEL 1 (
+    echo ERROR sha512sum
+    popd
+    endlocal
+    exit /b 1
+)
 popd
 
 endlocal
+exit /b 0

--- a/installer/release.bat
+++ b/installer/release.bat
@@ -38,35 +38,50 @@ echo %no%
 
 if "%no%" == "1" (
     call :download_libs force
+    if errorlevel 1 exit /b 1
     call :build_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm rebuild
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "2" (
     call :download_libs
+    if errorlevel 1 exit /b 1
     call :build_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm rebuild
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "3" (
     call :download_libs
+    if errorlevel 1 exit /b 1
     call :build_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "4" (
     call :download_libs
+    if errorlevel 1 exit /b 1
     call :build_libs
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "5" (
     call :build_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm rebuild
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "6" (
     call :build_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "7" (
@@ -83,24 +98,34 @@ if "%no%" == "10" (
 
 if "%no%" == "11" (
     call :download_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm_1 rebuild
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "12" (
     call :download_libs
+    if errorlevel 1 exit /b 1
     call :build_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm_2 rebuild
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "13" (
     call :download_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm_1
+    if errorlevel 1 exit /b 1
 )
 
 if "%no%" == "14" (
     call :download_libs
+    if errorlevel 1 exit /b 1
     call :build_libs
+    if errorlevel 1 exit /b 1
     call :build_teraterm_2
+    if errorlevel 1 exit /b 1
 )
 
 if not "%NOPAUSE%" == "1" pause
@@ -132,6 +157,10 @@ rem ####################
 setlocal
 cd /d %CUR%..\libs
 call buildall.bat
+if errorlevel 1 (
+    endlocal
+    exit /b 1
+)
 endlocal
 exit /b 0
 


### PR DESCRIPTION
## 概要

issue #1092 への対応。

`installer/release.bat` においてサブルーチンの呼び出し後にエラーチェックが行われていなかったため、ビルドが失敗しても GitHub Actions が正常終了してしまう問題を修正する。

## 変更内容

### `installer/release.bat`

- option 1〜6, 11〜14 の各 `call` の直後に `if errorlevel 1 exit /b 1` を追加
  - サブルーチン（`:download_libs`, `:build_libs`, `:build_teraterm`, `:build_teraterm_1`, `:build_teraterm_2`）が失敗した場合にスクリプトを即座に終了するようにした
- `:build_libs` サブルーチンにエラー伝播を追加
  - `buildall.bat` が失敗した場合に `exit /b 1` を返すようにした（これまでは常に `exit /b 0` を返していた）

### `installer/create_package.bat`

- 各コマンド（`cmake -E copy_directory`, `%INNO_SETUP%`, `cmake -E tar`, `cmake -E sha256sum`, `cmake -E sha512sum`）の直後にエラーチェックを追加
- `pushd Output` ブロック内でエラーが発生した場合は `popd` してから `exit /b 1` するようにした
- 末尾に `exit /b 0` を追加（これまでは最後のコマンドの終了コードがそのまま返っていた）

## テスト結果

コミットを1つにsquashし、最新の main にリベースした状態（コミット `33a653af1`）で再検証済み。各ケースをそれぞれ独立したブランチにcherry-pickして並行実行し、いずれも想定通りの箇所で停止することを確認した。

| ケース | 内容 | 結果 | Actions |
|--------|------|------|---------|
| A | `build_common.bat` に `exit /b 1` を追加 → `:build_teraterm_1` 失敗 | build_common job の Build step で停止 ✓ | https://github.com/m-tmatma/teraterm/actions/runs/30899569406 |
| B | `teraterm.cpp` に `#error` を追加 → コンパイルエラー | build_arch job の Build step で停止 ✓ | https://github.com/m-tmatma/teraterm/actions/runs/30899569303 |
| C | `buildall.bat` に `exit /b 1` を追加 → `:build_libs` 失敗 | build_arch job の Build step で停止 ✓ | https://github.com/m-tmatma/teraterm/actions/runs/30899567031 |
| D | `teraterm.iss` に `#error` を追加 → `create_package.bat` 失敗 | build_arch job の Build step で停止 ✓ | https://github.com/m-tmatma/teraterm/actions/runs/30899567665 |

検証に使用したブランチは確認後に削除済み。
