### PR TITLE
Mfc/#1241

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -92,6 +92,15 @@
         This bug was introduced in 5.5.2.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1195" target="_blank">issue #1195</a>)
       </li>
+      <li>
+        Fixed an issue where old bg theme files were not being loaded correctly.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1128" target="_blank">issue #1128</a>)
+      </li>
+      <li>
+        Fixed an issue where speeds above 115200 could not be selected when opening the Serial port tab ("Additional settings &gt; <a href="../menu/setup-additional-serialport.html">Serial port</a>").
+        This bug was introduced in 5.0.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1241" target="_blank">issue #1241</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -92,6 +92,15 @@
         5.5.2 からの不具合。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1195" target="_blank">issue #1195</a>)
       </li>
+      <li>
+        古いテーマファイルが正しく読み込まれない問題を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1128" target="_blank">issue #1128</a>)
+      </li>
+      <li>
+        Serial poot タブ ("Additional settings &gt; <a href="../menu/setup-additional-serialport.html">Serial port</a>") を開いたときに、115200 以上の速度が選択状態にならない問題を修正した。
+        5.0 からの不具合。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1241" target="_blank">issue #1241</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/teraterm/serial_pp.cpp
+++ b/teraterm/teraterm/serial_pp.cpp
@@ -371,7 +371,7 @@ static INT_PTR CALLBACK SerialDlg(HWND Dialog, UINT Message, WPARAM wParam, LPAR
 				SetDropDownList(Dialog, IDC_SERIALBAUD, BaudList, 0);
 				i = sel = 0;
 				while (BaudList[i] != NULL) {
-					if ((WORD)atoi(BaudList[i]) == ts->Baud) {
+					if ((DWORD)atoi(BaudList[i]) == ts->Baud) {
 						SendDlgItemMessage(Dialog, IDC_SERIALBAUD, CB_SETCURSEL, i, 0);
 						sel = 1;
 						break;


### PR DESCRIPTION
Serial port タブを開いたとき、Speed が 115200 以上の場合に選択状態にならないのを修正 #1241

(cherry picked from commit fd556f0d22f66350fb9cf6d0691e9d75e6cf5e7a)