### PR TITLE
Refactor/#1279 dmp filename

### DIFF
--- a/teraterm/teraterm/teraterm.cpp
+++ b/teraterm/teraterm/teraterm.cpp
@@ -124,7 +124,7 @@ static void init(void)
 {
 	DLLInit();
 	WinCompatInit();
-	DebugSetException(L"teraterm");
+	DebugSetException(L"ttermpro");
 	LoadSpecialFont();
 #if defined(DEBUG_OPEN_CONSOLE_AT_STARTUP)
 	DebugConsoleOpen();


### PR DESCRIPTION
ttermpro.exe での例外は ttermpro_*.dmp として出力するようにした #1279