### PR TITLE
録画中にサーバ側から切断しても録画停止できるようにした

### DIFF
--- a/TTXSamples/TTXttyrec/TTXttyrec.c
+++ b/TTXSamples/TTXttyrec/TTXttyrec.c
@@ -188,7 +188,7 @@ static void PASCAL TTXModifyMenu(HMENU menu) {
 
 static void PASCAL TTXModifyPopupMenu(HMENU menu) {
   if (menu==pvar->FileMenu) {
-    if (pvar->cv->Ready)
+    if (pvar->cv->Ready || pvar->record)
       EnableMenuItem(pvar->FileMenu, ID_MENUITEM, MF_BYCOMMAND | MF_ENABLED);
     else
       EnableMenuItem(pvar->FileMenu, ID_MENUITEM, MF_BYCOMMAND | MF_GRAYED);

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -6817,6 +6817,10 @@ SYNOPSIS:
     Fixed display corruption when playing a tty file after a non-tty file.
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    Enabled stopping TTY recording after disconnection.
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1284" target="_blank">issue #1284</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -6827,6 +6827,10 @@
     ttyファイルでないファイルを再生した後、ttyファイルを再生すると表示が崩れる問題を修正した。
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    切断後にTTY録画を停止できるようにした。
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1284" target="_blank">issue #1284</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>


### PR DESCRIPTION
issues #1284 の対策です。

録画中にサーバ側から切断しても録画は停止しない。
しかし、接続中でないため、録画停止を行うメニューは選択不可状態になる。
接続中または録画中は録画停止を行うメニューは選択できるように修正した。