### PR TITLE
TTYファイル選択の開始ディレクトリをぶれないように修正

### DIFF
--- a/TTXSamples/TTXttyrec/TTXttyplay.c
+++ b/TTXSamples/TTXttyrec/TTXttyplay.c
@@ -8,10 +8,10 @@
 #include <stdio.h>
 #include <string.h>
 
-
 #include "inifile_com.h"
 #include "ttcommdlg.h"
 #include "codeconv.h"
+#include "ttlib_types.h"
 
 #include "gettimeofday.h"
 
@@ -220,6 +220,7 @@ static void PASCAL TTXInit(PTTSet ts, PComVar cv) {
 	gettimeofday(&(pvar->last) /*, NULL*/ );
 	pvar->wait.tv_sec = 0;
 	pvar->wait.tv_usec = 1;
+	pvar->openfnW = NULL;
 	pvar->skip = 0;
 	pvar->skip_ini = 5;
 	pvar->maxwait = 0;
@@ -672,6 +673,14 @@ static int PASCAL TTXProcessCommand(HWND hWin, WORD cmd) {
 			TTOPENFILENAMEW ofn;
 			wchar_t *openfn;
 			wchar_t *uimsg1, *uimsg2;
+			wchar_t *logdir;
+
+			if (pvar->openfnW == NULL) {
+				logdir = GetTermLogDir(pvar->ts);
+			}
+			else {
+				logdir = ExtractDirNameW(pvar->openfnW);
+			}
 
 			GetI18nStrWW("TTXttyrec", "FILE_FILTER", L"ttyrec(*.tty)\\0*.tty\\0All files(*.*)\\0*.*\\0\\0", pvar->ts->UILanguageFileW, &uimsg1);
 			GetI18nStrWW("TTXttyrec", "FILE_DEFAULTEXTENSION", L"tty", pvar->ts->UILanguageFileW, &uimsg2);
@@ -679,6 +688,7 @@ static int PASCAL TTXProcessCommand(HWND hWin, WORD cmd) {
 			ofn.hwndOwner = hWin;
 			ofn.lpstrFilter = uimsg1;
 			ofn.lpstrDefExt = uimsg2;
+			ofn.lpstrInitialDir = logdir;
 			// ofn.lpstrTitle = L"";
 			ofn.Flags = OFN_FILEMUSTEXIST;
 
@@ -692,6 +702,7 @@ static int PASCAL TTXProcessCommand(HWND hWin, WORD cmd) {
 			}
 			free(uimsg1);
 			free(uimsg2);
+			free(logdir);
 		}
 		return 1;
 	case ID_MENU_AGAIN:

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -6817,6 +6817,10 @@ SYNOPSIS:
     Fixed display corruption when playing a tty file after a non-tty file.
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    Fixed the initial directory for the tty file playback file selection dialog to ensure consistency.
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1382" target="_blank">issue #1382</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -6827,6 +6827,10 @@
     ttyファイルでないファイルを再生した後、ttyファイルを再生すると表示が崩れる問題を修正した。
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    ttyファイル再生のファイル選択ダイアログの初期ディレクトリは一貫性を保つように修正した。
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1382" target="_blank">issue #1382</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>


### PR DESCRIPTION
issues #1382 の対策です。

ttyplayの再生ファイル選択ダイアログは、ほかのファイル選択ダイアログを使うとディレクトリが変わってしまうことがある。
最後に再生したttyファイルのディレクトリを使うようにした。
最後に再生したttyファイルが無い場合は、GetTermLogDir() を使うようにした。