### PR TITLE
TTYファイルの保存ディレクトリを端末ログのディレクトリに変更

### DIFF
--- a/TTXSamples/TTXttyrec/TTXttyrec.c
+++ b/TTXSamples/TTXttyrec/TTXttyrec.c
@@ -11,6 +11,7 @@
 
 #include "inifile_com.h"
 #include "ttcommdlg.h"
+#include "ttlib_types.h"
 
 #include "gettimeofday.h"
 
@@ -210,10 +211,13 @@ static int PASCAL TTXProcessCommand(HWND hWin, WORD cmd)
 			TTOPENFILENAMEW ofn;
 			wchar_t *fname;
 			wchar_t *uimsg1, *uimsg2;
+			wchar_t *logdir;
 
 			if (pvar->fh != INVALID_HANDLE_VALUE) {
 				CloseHandle(pvar->fh);
 			}
+
+			logdir = GetTermLogDir(pvar->ts);
 
 			GetI18nStrWW("TTXttyrec", "FILE_FILTER", L"ttyrec(*.tty)\\0*.tty\\0All files(*.*)\\0*.*\\0\\0", pvar->ts->UILanguageFileW, &uimsg1);
 			GetI18nStrWW("TTXttyrec", "FILE_DEFAULTEXTENSION", L"tty", pvar->ts->UILanguageFileW, &uimsg2);
@@ -222,7 +226,7 @@ static int PASCAL TTXProcessCommand(HWND hWin, WORD cmd)
 			ofn.lpstrFilter = uimsg1;
 			ofn.lpstrFile = NULL;
 			ofn.lpstrDefExt = uimsg2;
-			ofn.lpstrInitialDir = pvar->ts->LogDirW;
+			ofn.lpstrInitialDir = logdir;
 			//ofn.lpstrTitle = L"";
 			ofn.Flags = OFN_OVERWRITEPROMPT;
 			if (TTGetSaveFileNameW(&ofn, &fname)) {
@@ -241,6 +245,7 @@ static int PASCAL TTXProcessCommand(HWND hWin, WORD cmd)
 			}
 			free(uimsg1);
 			free(uimsg2);
+			free(logdir);
 		}
 		return 1;
 	}

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -6817,6 +6817,10 @@ SYNOPSIS:
     Fixed display corruption when playing a tty file after a non-tty file.
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    Modified first save location for tty file to the "Terminal log folder" directory.
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1384" target="_blank">issue #1384</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -6827,6 +6827,10 @@
     ttyファイルでないファイルを再生した後、ttyファイルを再生すると表示が崩れる問題を修正した。
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    ttyファイルを最初に保存する場所は「端末ログ」フォルダに変更した。
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1384" target="_blank">issue #1384</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>


### PR DESCRIPTION
issues #1384 の対策です。

TTYファイルは、端末ログの一種である。
メニュー`TTY Record` で録画の保存ディレクトリは、ログディレクトリより端末ログのディレクトリのほうが適切である。

録画の保存ディレクトリは、 ts->LogDirW から GetTermLogDir() に変更した。
