### PR TITLE
TTYファイル再生のタイトル表示に短いパス名での表示を追加する

### DIFF
--- a/TTXSamples/TTXttyrec/TTXttyplay.c
+++ b/TTXSamples/TTXttyrec/TTXttyplay.c
@@ -73,6 +73,9 @@ typedef struct {
 	char origOLDTitle[TitleBuffSize];
 	int mode_flag;
 	char *fmt_time;
+	char *origHostName;
+	int name_cnt_ini;
+	int name_cnt;
 } TInstVar;
 
 static TInstVar *pvar;
@@ -206,6 +209,44 @@ HMENU GetSubMenuByChildID(HMENU menu, UINT id) {
   return NULL;
 }
 
+wchar_t *ExtractPath(wchar_t *path, int n)
+{
+	if (n > 0) {
+		wchar_t *p = &path[wcslen(path)];
+		int cnt = 0;
+		while (p > path) {
+			p--;
+			if (*p == L'\\' || *p == L'/') {
+				cnt++;
+				if (cnt >= n) {
+					return &p[1];
+				}
+			}
+		}
+	}
+	return path;
+}
+
+void ChangeHostName()
+{
+	free(pvar->origHostName);
+	pvar->origHostName = _strdup(pvar->ts->HostName);
+	wchar_t *hostnameW = ToWcharA(pvar->origHostName);
+	char *hostname = ToCharW(ExtractPath(hostnameW, pvar->name_cnt));
+	strncpy_s(pvar->ts->HostName, sizeof(pvar->ts->HostName), hostname, _TRUNCATE);
+	free(hostname);
+	free(hostnameW);
+}
+
+void RestoreOLDHostName()
+{
+	if (pvar->origHostName != NULL) {
+		strncpy_s(pvar->ts->HostName, sizeof(pvar->ts->HostName), pvar->origHostName, _TRUNCATE);
+		free(pvar->origHostName);
+		pvar->origHostName = NULL;
+	}
+}
+
 static void PASCAL TTXInit(PTTSet ts, PComVar cv) {
 	pvar->ts = ts;
 	pvar->cv = cv;
@@ -230,6 +271,9 @@ static void PASCAL TTXInit(PTTSet ts, PComVar cv) {
 	pvar->open_error = FALSE;
 	pvar->mode_flag = 0;
 	pvar->fmt_time = NULL;
+	pvar->origHostName = NULL;
+	pvar->name_cnt_ini = 0;
+	pvar->name_cnt = 0;
 }
 
 void RestoreTitle() {
@@ -267,6 +311,7 @@ static HANDLE PASCAL TTXCreateFile(LPCSTR FName, DWORD AcMode, DWORD ShMode,
 		}
 		else {
 			pvar->open_error = FALSE;
+			ChangeHostName();
 		}
 	}
 
@@ -571,6 +616,8 @@ static void PASCAL TTXCloseFile(TTXFileHooks *hooks) {
 		pvar->wait.tv_usec = 0;
 		pvar->nowait = pvar->nowait_ini;
 		pvar->speed = 0;
+		RestoreOLDHostName();
+		pvar->name_cnt = pvar->name_cnt_ini;
 	}
 }
 
@@ -642,6 +689,14 @@ static void PASCAL TTXParseParam(wchar_t *Param, PTTSet ts, PCHAR DDETopic) {
 			pvar->maxwait = max;
 			pvar->minwait = min;
 		}
+		else if (_wcsnicmp(buff, L"/TPN", 5) == 0 || _wcsnicmp(buff, L"/TPN=", 5) == 0) {
+			int cnt = 1;
+			if (buff[4] == L'=') {
+				cnt = 0;
+	    		swscanf_s(&buff[5], L"%d", &cnt);
+			}
+			pvar->name_cnt = cnt;
+		}
 	}
 }
 
@@ -656,6 +711,8 @@ static void PASCAL TTXReadIniFile(const wchar_t *fn, PTTSet ts) {
 	ConvertSafeStrFtimeFormat(buff);
 	free(pvar->fmt_time);
 	pvar->fmt_time = ToCharW(buff);
+	pvar->name_cnt_ini = GetPrivateProfileIntAFileW(INISECTION, "TitlePathMode", 0, fn);
+	pvar->name_cnt = pvar->name_cnt_ini;
 }
 
 static void PASCAL TTXGetSetupHooks(TTXSetupHooks *hooks) {

--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -6817,6 +6817,11 @@ SYNOPSIS:
     Fixed display corruption when playing a tty file after a non-tty file.
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    Added support for displaying short length of the file path in the title bar during playback.<br>
+    The file path options as added the filename or the filename include the parent directory.
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1386" target="_blank">issue #1386</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>

--- a/doc/en/html/commandline/ttxttyplay.html
+++ b/doc/en/html/commandline/ttxttyplay.html
@@ -48,6 +48,20 @@ You can use the following command line parameters on TTXttyplay.
           If the wait period is less than MinWait, that wait will be skipped.</li>
     </ul>
   </dd>
+
+  <dt id="TPN">/TPN</dt>
+  <dd>It displays only filename in the title bar path. (same /TPN=1)</dd>
+
+  <dt id="TPN=">/TPN=&lt;count#&gt;</dt>
+  <dd>Number of path segment of displayed in the title bar
+  <dd>
+      <ul>
+        <li><span class="syntax">/TPN=0</span> full path</li>
+        <li><span class="syntax">/TPN=1</span> filename</li>
+        <li><span class="syntax">/TPN=2</span> parent directory name and filename</li>
+      </ul>
+      If count# is set to 3 or grater, multiple parent directory name and filename are displayed.
+  </dd>
 </dl>
 
 

--- a/doc/en/html/setup/teraterm-ini.html
+++ b/doc/en/html/setup/teraterm-ini.html
@@ -2105,6 +2105,12 @@ list3=3rd item
 		<td style="width:250px;">%Y/%m/%d %H:%M:%S</td>
 		<td></td>
 	</tr>
+	<tr>
+		<td id="TitlePathMode">TitlePathMode</td>
+		<td style="width:250px;"></td>
+		<td style="width:250px;">0</td>
+		<td></td>
+	</tr>
 </table>
 
 <h2>TTXRecurringCommand</h2>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -6827,6 +6827,11 @@
     ttyファイルでないファイルを再生した後、ttyファイルを再生すると表示が崩れる問題を修正した。
     (<a href="https://github.com/TeraTermProject/teraterm/issues/1323" target="_blank">issue #1323</a>)
   </li>
+  <li>
+    再生中のタイトルバーにファイルパスを短縮して表示する機能を追加しました。<br>
+    ファイルパスの表示オプションとして、ファイル名のみ、および親ディレクトリ付きファイル名を選択できます。
+    (<a href="https://github.com/TeraTermProject/teraterm/issues/1386" target="_blank">issue #1386</a>)
+  </li>
 </ul>
 
 <h3 id="ttyrec_1.06">2025.08.03 (Ver 1.06)</h3>

--- a/doc/ja/html/commandline/ttxttyplay.html
+++ b/doc/ja/html/commandline/ttxttyplay.html
@@ -48,6 +48,20 @@ TTXttyplayでは以下のコマンドラインオプションが使用できます。
           ウェイト時間が指定時間以下の場合、ウェイトせずスキップするようにします。</li>
     </ul>
   </dd>
+
+  <dt id="TPN">/TPN</dt>
+  <dd>タイトルバー表示のパスをファイル名のみにします。(/TPN=1 と同じ)</dd>
+
+  <dt id="TPN">/TPN=&lt;count#&gt;</dt>
+  <dd>タイトルバー表示のパス数
+  <dd>
+      <ul>
+        <li><span class="syntax">/TPN=0</span> フルパス</li>
+        <li><span class="syntax">/TPN=1</span> ファイル名のみ</li>
+        <li><span class="syntax">/TPN=2</span> 親ディレクトリ名とファイル名</li>
+      </ul>
+      count#に3以上を設定した場合は、複数の親ディレクトリ名とファイル名を表示します。
+  </dd>
 </dl>
 
 

--- a/doc/ja/html/setup/teraterm-ini.html
+++ b/doc/ja/html/setup/teraterm-ini.html
@@ -2105,6 +2105,12 @@ list3=3rd item
 		<td style="width:250px;">%Y/%m/%d %H:%M:%S</td>
 		<td></td>
 	</tr>
+	<tr>
+		<td id="TitlePathMode">TitlePathMode</td>
+		<td style="width:250px;"></td>
+		<td style="width:250px;">0</td>
+		<td></td>
+	</tr>
 </table>
 
 <h2>TTXRecurringCommand</h2>

--- a/installer/release/TERATERM.INI
+++ b/installer/release/TERATERM.INI
@@ -1057,6 +1057,12 @@ RecordStartSize=on
 ;   %Y-%m-%dT%H:%M:%S    ... 2026-05-24T09:48:40
 ;   %a %b %e %H:%M:%S %Y ... Sun May 24 09:48:40 2026
 ;TimeFormat=%Y/%m/%d %H:%M:%S
+
+; Displayed file path mode support in Title bar
+;  0 ... Full path
+;  1 ... Filename only
+;  2 ... Parent and filename
+;  3 or over ... Multiple parent and filename
 ;TitlePathMode=1
 
 [TTXRecurringCommand]

--- a/installer/release/TERATERM.INI
+++ b/installer/release/TERATERM.INI
@@ -1057,6 +1057,7 @@ RecordStartSize=on
 ;   %Y-%m-%dT%H:%M:%S    ... 2026-05-24T09:48:40
 ;   %a %b %e %H:%M:%S %Y ... Sun May 24 09:48:40 2026
 ;TimeFormat=%Y/%m/%d %H:%M:%S
+;TitlePathMode=1
 
 [TTXRecurringCommand]
 Enable=off


### PR DESCRIPTION
issues #1386 の対策

TERATERM.INI に項目で表示の切り替えをする。
項目：[ttyrec] TitlePathMode

0: フルパス(設定省略時)
1: ファイル名のみ
2: 親ディレクトリとファイル名

コマンドラインオプション「/TPN」で表示の切り替えをする。
/TPN        ... ファイル名のみ
/TPN=0    ... フルパス
/TPN=1    ... ファイル名のみ
/TPN=2    ... 親ディレクトリとファイル名
なし         ... TERATERM.INI に従う