### PR TITLE
fix PrintDlg focus #1448

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -115,6 +115,10 @@
         Fixed an issue where YMODEM transfers from the local host to a remote system did not stop on the receiver side when the Cancel button was pressed during file transmission.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1439" target="_blank">issue #1439</a>)
       </li>
+      <li>
+        Fixed an issue where Print dialog("File &gt; Print...") could not be operated with the keyboard.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1448" target="_blank">issue #1448</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -114,6 +114,10 @@
         YMODEMを使用したファイル送信中にCancelボタンを押下しても、受信側のYMODEMが停止しない不具合を修正した。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1439" target="_blank">issue #1439</a>)
       </li>
+      <li>
+        印刷ダイアログ("File &gt; Print...")がキーボードで操作できない不具合を修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1448" target="_blank">issue #1448</a>)
+      </li>
     </ul>
   </li>
 

--- a/teraterm/teraterm/teraprn.cpp
+++ b/teraterm/teraterm/teraprn.cpp
@@ -58,6 +58,10 @@ static BOOL PrintAbortFlag = FALSE;
 
 static UINT_PTR CALLBACK PrintHookProc(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam)
 {
+	if (uiMsg == WM_INITDIALOG) {
+		// TRUEを返すとデフォルトのコントロールにフォーカスが設定される
+		return TRUE;
+	}
 	(void)hdlg;
 	(void)uiMsg;
 	(void)wParam;


### PR DESCRIPTION
- プリントダイアログのフォーカスがおかしくなっていたので修正
- キーボードで操作できなかった(マウス操作は大丈夫だった)
- 動作しているWindowsのバージョンによって動作が異なる?
  - Tera Term 4.x系でも再現