### PR TITLE
connect マクロコマンドの /passwd= パラメータで、日本語(マルチバイト)パスワードによる認証が失敗する #1460

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -4302,12 +4302,14 @@ SYNOPSIS:
     </ul>
   </li-->
 
-  <!--li>Bug fixes
+  <li>Bug fixes
     <ul>
       <li>
+        Fixed the implementation to comply with RFC 4252 by sending the username and password specified via command-line options and macro commands in UTF-8.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1460" target="_blank">issue #1460</a>)
       </li>
     </ul>
-  </li-->
+  </li>
 
   <!--li>Misc
     <ul>

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -4309,12 +4309,14 @@
     </ul>
   </li-->
 
-  <!--li>バグ修正
+  <li>バグ修正
     <ul>
       <li>
+        RFC 4252 に準拠するよう、コマンドライン及びマクロコマンドで指定したユーザー名とパスワードを UTF-8 で送信するよう修正した。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1460" target="_blank">issue #1460</a>)
       </li>
     </ul>
-  </li-->
+  </li>
 
   <!--li>その他
     <ul>

--- a/ttssh2/ttxssh/auth.c
+++ b/ttssh2/ttxssh/auth.c
@@ -375,7 +375,7 @@ static void init_auth_dlg(PTInstVar pvar, HWND dlg, BOOL *UseControlChar)
 		EnableWindow(GetDlgItem(dlg, IDC_SSHUSERNAMELABEL), FALSE);
 	}
 	else if (strlen(pvar->ssh2_username) > 0) {
-		SetDlgItemText(dlg, IDC_SSHUSERNAME, pvar->ssh2_username);
+		SetDlgItemTextU8(dlg, IDC_SSHUSERNAME, pvar->ssh2_username);
 		if (pvar->ssh2_autologin == 1) {
 			EnableWindow(GetDlgItem(dlg, IDC_SSHUSERNAME), FALSE);
 			EnableWindow(GetDlgItem(dlg, IDC_USERNAME_OPTION), FALSE);

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -1027,8 +1027,8 @@ typedef struct {
 
 static BOOL IsEditHistorySelected(HWND dlg)
 {
-	LRESULT index = SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_GETCURSEL, 0, 0);
-	LRESULT data = SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_GETITEMDATA, (WPARAM)index, 0);
+	LRESULT index = SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_GETCURSEL, 0, 0);
+	LRESULT data = SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_GETITEMDATA, (WPARAM)index, 0);
 	return data == 999;
 }
 
@@ -1037,18 +1037,18 @@ static void SetHostDropdown(HWND dlg, const TTTSet *ts)
 	LRESULT index;
 	SetComboBoxHostHistory(dlg, IDC_HOSTNAME, MAXHOSTLIST, ts->SetupFNameW);
 	ExpandCBWidth(dlg, IDC_HOSTNAME);
-	SendDlgItemMessage(dlg, IDC_HOSTNAME, EM_LIMITTEXT, HostNameMaxLength - 1, 0);
-	if (SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_GETCOUNT, 0, 0) != 0) {
+	SendDlgItemMessageW(dlg, IDC_HOSTNAME, EM_LIMITTEXT, HostNameMaxLength - 1, 0);
+	if (SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_GETCOUNT, 0, 0) != 0) {
 		// 一番最初を選択する
-		SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_SETCURSEL, 0, 0);
+		SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_SETCURSEL, 0, 0);
 	} else {
 		// 選択しない、エディットボックスは空になる
-		SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_SETCURSEL, -1, 0);
+		SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_SETCURSEL, -1, 0);
 	}
 
 	// Edit historyを追加(ITEMDATA=999)
 	index = SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_ADDSTRING, 0, (LPARAM)L"<Edit host list...>");
-	SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_SETITEMDATA, index, 999);
+	SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_SETITEMDATA, index, 999);
 }
 
 static void OpenEditHistory(HWND dlg, TTTSet *ts)
@@ -1060,17 +1060,17 @@ static void OpenEditHistory(HWND dlg, TTTSet *ts)
 	data.title = L"Edit Host list";
 	if (EditHistoryDlg(NULL, dlg, &data)) {
 		// 編集されたので、ドロップダウンを再設定する
-		SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_RESETCONTENT, 0, 0);
+		SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_RESETCONTENT, 0, 0);
 
 		SetHostDropdown(dlg, ts);
 	}
 
-	if (SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_GETCOUNT, 0, 0) > 1) {
+	if (SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_GETCOUNT, 0, 0) > 1) {
 		// 一番最初を選択する
-		SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_SETCURSEL, 0, 0);
+		SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_SETCURSEL, 0, 0);
 	} else {
 		// "<Edit History...>のみ、選択しない、エディットボックスは空になる
-		SendDlgItemMessageA(dlg, IDC_HOSTNAME, CB_SETCURSEL, -1, 0);
+		SendDlgItemMessageW(dlg, IDC_HOSTNAME, CB_SETCURSEL, -1, 0);
 	}
 }
 
@@ -1206,7 +1206,7 @@ static INT_PTR CALLBACK TTXHostDlg(HWND dlg, UINT msg, WPARAM wParam, LPARAM lPa
 		CheckRadioButton(dlg, IDC_HOSTTCPIP, IDC_HOSTSERIAL,
 		                 IDC_HOSTTCPIP + GetHNRec->PortType - 1);
 		if (GetHNRec->PortType == IdTCPIP) {
-			SendMessageA(dlg, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(dlg, IDC_HOSTNAME), TRUE);
+			SendMessageW(dlg, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(dlg, IDC_HOSTNAME), TRUE);
 			enable_dlg_items(dlg, IDC_HOSTCOMLABEL, IDC_HOSTCOM, FALSE);
 
 			enable_dlg_items(dlg, IDC_SSH_VERSION, IDC_SSH_VERSION, TRUE);

--- a/ttssh2/ttxssh/ttxssh.c
+++ b/ttssh2/ttxssh/ttxssh.c
@@ -1715,10 +1715,10 @@ static void PASCAL TTXParseParam(wchar_t *param, PTTSet ts, PCHAR DDETopic)
 				}
 
 			} else if (wcsncmp(option + 1, L"user=", 5) == 0) {
-				WideCharToACP_t(option + 6, pvar->ssh2_username, sizeof(pvar->ssh2_username));
+				WideCharToMultiByte(CP_UTF8, 0, option + 6, -1, pvar->ssh2_username, sizeof(pvar->ssh2_username), NULL, NULL);
 
 			} else if (wcsncmp(option + 1, L"passwd=", 7) == 0) {
-				WideCharToACP_t(option + 8, pvar->ssh2_password, sizeof(pvar->ssh2_password));
+				WideCharToMultiByte(CP_UTF8, 0, option + 8, -1, pvar->ssh2_password, sizeof(pvar->ssh2_password), NULL, NULL);
 
 			} else if (wcsncmp(option + 1, L"keyfile=", 8) == 0) {
 				const wchar_t *keyfileW = option + 9;
@@ -1825,14 +1825,10 @@ static void PASCAL TTXParseParam(wchar_t *param, PTTSet ts, PCHAR DDETopic)
 			//   将来的にtelnet authentication optionをサポートした時は
 			//   Tera Term本体で処理するようにする予定。
 			//
-			char *optionA;
 			wchar_t *p;
 			p = wcschr(option, '@');
 			*p = 0;
-
-			optionA = ToCharW(option);
-			strncpy_s(pvar->ssh2_username, sizeof(pvar->ssh2_username), optionA, _TRUNCATE);
-			free(optionA);
+			WideCharToMultiByte(CP_UTF8, 0, option, -1, pvar->ssh2_username, sizeof(pvar->ssh2_username), NULL, NULL);
 
 			// ユーザ名部分をスペースで潰す。
 			// 後続のTTXやTera Term本体で解釈する時にはスペースを読み飛ばすので、
@@ -4880,6 +4876,11 @@ static void _dquote_string(const wchar_t *str, wchar_t *dst, size_t dst_len)
 
 static void dquote_stringW(const wchar_t *str, wchar_t *dst, size_t dst_len)
 {
+	if (str == NULL || *str == L'\0') {
+		*dst = L'\0';
+		return;
+	}
+
 	// ",スペース,;,^A-^_ が含まれる場合にはクオートする
 	if (wcschr(str, '"') != NULL ||
 	    wcschr(str, ' ') != NULL ||
@@ -4922,14 +4923,11 @@ static void dquote_stringW(const wchar_t *str, wchar_t *dst, size_t dst_len)
 	wcsncpy_s(dst, dst_len, str, _TRUNCATE);
 }
 
-static void dquote_string(const char *str, char *dst, size_t dst_len)
+static void dquote_stringU8toW(const char *str, wchar_t *dst, size_t dst_len)
 {
-	wchar_t *dstW = malloc(sizeof(wchar_t) * dst_len);
-	wchar_t *strW = ToWcharA(str);
-	dquote_stringW(strW, dstW, dst_len);
-	WideCharToACP_t(dstW, dst, dst_len);
+	wchar_t *strW = ToWcharU8(str);
+	dquote_stringW(strW, dst, dst_len);
 	free(strW);
-	free(dstW);
 }
 
 static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
@@ -4995,7 +4993,7 @@ static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
 
 		// セッション複製の場合は、自動ログイン用パラメータを付ける。
 		if (wcsstr(buf, L"DUPLICATE")) {
-			char mark[MAX_PATH];
+			wchar_t mark[MAX_PATH];
 			wchar_t tmp[MAX_PATH*2];
 
 			// 自動ログインの場合は下記フラグが0のため、必要なコマンドを付加する。
@@ -5005,22 +5003,25 @@ static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 			}
 
+			wchar_t user[MAX_PATH];
+			dquote_stringU8toW(pvar->auth_state.user, user, _countof(user));
+
 			// パスワードを覚えていて、かつ複数認証要求でない場合にのみコマンドラインに渡す。
 			if (pvar->settings.remember_password &&
 			    !pvar->auth_state.multiple_required_auth &&
 			    pvar->auth_state.cur_cred.method == SSH_AUTH_PASSWORD) {
-				dquote_string(pvar->auth_state.cur_cred.password, mark, sizeof(mark));
+				dquote_stringU8toW(pvar->auth_state.cur_cred.password, mark, _countof(mark));
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
-				             L" /auth=password /user=%hs /passwd=%hs", pvar->auth_state.user, mark);
+				             L" /auth=password /user=%s /passwd=%s", user, mark);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
 			} else if (pvar->settings.remember_password &&
 			           !pvar->auth_state.multiple_required_auth &&
 			           pvar->auth_state.cur_cred.method == SSH_AUTH_RSA) {
 				wchar_t markW[MAX_PATH];
-				dquote_string(pvar->auth_state.cur_cred.password, mark, sizeof(mark));
+				dquote_stringU8toW(pvar->auth_state.cur_cred.password, mark, _countof(mark));
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
-				             L" /auth=publickey /user=%hs /passwd=%hs", pvar->auth_state.user, mark);
+				             L" /auth=publickey /user=%s /passwd=%s", user, mark);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
 				dquote_stringW(pvar->session_settings.DefaultRSAPrivateKeyFile, markW, _countof(markW));
@@ -5030,15 +5031,15 @@ static void PASCAL TTXSetCommandLine(wchar_t *cmd, int cmdlen, PGetHNRec rec)
 			} else if (pvar->settings.remember_password &&
 			           !pvar->auth_state.multiple_required_auth &&
 			           pvar->auth_state.cur_cred.method == SSH_AUTH_TIS) {
-				dquote_string(pvar->auth_state.cur_cred.password, mark, sizeof(mark));
+				dquote_stringU8toW(pvar->auth_state.cur_cred.password, mark, _countof(mark));
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
-				             L" /auth=challenge /user=%hs /passwd=%hs", pvar->auth_state.user, mark);
+				             L" /auth=challenge /user=%s /passwd=%s", user, mark);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
 			} else if (pvar->auth_state.cur_cred.method == SSH_AUTH_PAGEANT &&
 			           !pvar->auth_state.multiple_required_auth) {
 				_snwprintf_s(tmp, _countof(tmp), _TRUNCATE,
-				             L" /auth=pageant /user=%hs", pvar->auth_state.user);
+				             L" /auth=pageant /user=%s", user);
 				wcsncat_s(cmd, cmdlen, tmp, _TRUNCATE);
 
 			} else {

--- a/ttssh2/ttxssh/ttxssh.h
+++ b/ttssh2/ttxssh/ttxssh.h
@@ -299,8 +299,8 @@ typedef struct _TInstVar {
 	int ssh2_autologin;
 	int ask4passwd;
 	SSHAuthMethod ssh2_authmethod;
-	char ssh2_username[MAX_PATH];
-	char ssh2_password[MAX_PATH];
+	char ssh2_username[MAX_PATH];	// UTF-8
+	char ssh2_password[MAX_PATH];	// UTF-8
 	wchar_t ssh2_keyfile[MAX_PATH];
 	time_t ssh_heartbeat_tick;
 	HANDLE ssh_heartbeat_thread;


### PR DESCRIPTION
コマンドライン及びマクロコマンドで指定したユーザー名とパスワードをUTF-8として扱い、日本語(マルチバイト)を使用可能とする修正案をお送りさせて頂きます。