### PR TITLE
コンパイル時の警告を対策 #1496

### DIFF
--- a/cygwin/cygterm/cygterm_cfg.cpp
+++ b/cygwin/cygterm/cygterm_cfg.cpp
@@ -161,11 +161,11 @@ static void env_destry(sh_env_t *envp)
 
 sh_env_t *create_sh_env(void)
 {
-	sh_env_t *sh_env = (sh_env_t *)calloc(sizeof(*sh_env), 1);
+	sh_env_t *sh_env = (sh_env_t *)calloc(1, sizeof(*sh_env));
 	if (sh_env == NULL) {
 		return NULL;
 	}
-	sh_env_private_t *pr_data = (sh_env_private_t *)calloc(sizeof(*pr_data), 1);
+	sh_env_private_t *pr_data = (sh_env_private_t *)calloc(1, sizeof(*pr_data));
 	if (pr_data == NULL) {
 		free(sh_env);
 		return NULL;
@@ -377,11 +377,11 @@ static void dump(cfg_data_t *cfg_data, void (*print)(const char* msg, ...))
 
 cfg_data_t *create_cfg(void)
 {
-	cfg_data_t *cfg_data = (cfg_data_t *)calloc(sizeof(*cfg_data), 1);
+	cfg_data_t *cfg_data = (cfg_data_t *)calloc(1, sizeof(*cfg_data));
 	if (cfg_data == NULL) {
 		return NULL;
 	}
-	cfg_private_data_t *pr_data = (cfg_private_data_t *)calloc(sizeof(*pr_data), 1);
+	cfg_private_data_t *pr_data = (cfg_private_data_t *)calloc(1, sizeof(*pr_data));
 	if (pr_data == NULL) {
 		free(cfg_data);
 		return NULL;

--- a/teraterm/common/ttlib.c
+++ b/teraterm/common/ttlib.c
@@ -980,5 +980,6 @@ DllExport void GetMessageboxFont(LOGFONTA *logfont)
 	nci.cbSize = st_size;
 	r = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, st_size, &nci, 0);
 	assert(r == TRUE);
+	(void)r;
 	*logfont = nci.lfStatusFont;
 }

--- a/teraterm/common/ttlib_static_cpp.cpp
+++ b/teraterm/common/ttlib_static_cpp.cpp
@@ -1575,6 +1575,7 @@ void GetMessageboxFontW(LOGFONTW *logfont)
 	nci.cbSize = st_size;
 	r = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, st_size, &nci, 0);
 	assert(r == TRUE);
+	(void)r;
 	*logfont = nci.lfStatusFont;
 }
 

--- a/teraterm/teraterm/broadcast.cpp
+++ b/teraterm/teraterm/broadcast.cpp
@@ -890,6 +890,7 @@ static INT_PTR CALLBACK BroadcastCommandDlgProc(HWND hWnd, UINT msg, WPARAM wp, 
 						UpdateSetupTerminalNewlineCode(ts.CRSend);
 						pVTWin->SetupTerm();
 					}
+					return FALSE;
 
 				case IDC_SUBMITKEY_TYPE:
 					SubmitKeyType = GetCurSel(hDlgWnd, IDC_SUBMITKEY_TYPE);

--- a/teraterm/teraterm/color_sample.cpp
+++ b/teraterm/teraterm/color_sample.cpp
@@ -97,7 +97,7 @@ static LRESULT CALLBACK CSProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam
  */
 ColorSample *ColorSampleInit(HWND hWnd, HFONT hFont)
 {
-	ColorSampleWork *work = (ColorSampleWork *)calloc(sizeof(*work), 1);
+	ColorSampleWork *work = (ColorSampleWork *)calloc(1, sizeof(*work));
 	work->hWnd = hWnd;
 	work->SampleFont = hFont;
 	work->OrigProc = (WNDPROC)SetWindowLongPtrW(hWnd, GWLP_WNDPROC, (LONG_PTR)CSProc);

--- a/teraterm/ttpmacro/ListDlg.cpp
+++ b/teraterm/ttpmacro/ListDlg.cpp
@@ -279,12 +279,16 @@ LRESULT CListDlg::DlgProc(UINT msg, WPARAM wp, LPARAM lp)
 				Relocation(FALSE, WW, WH);
 				return TRUE;
 			}
+			// dpi 不一致時は何もしない
+			break;
 		case WM_GETMINMAXINFO:
 			if (GetMonitorDpiFromWindow(m_hWnd) == dpi) {
 				pmmi->ptMinTrackSize.x = init_WW;
 				pmmi->ptMinTrackSize.y = init_WH;
 				return TRUE;
 			}
+			// dpi 不一致時は何もしない
+			break;
 		case WM_COMMAND:
 			if (m_ext & ExtListBoxDoubleclick) {
 				if (HIWORD(wp) == LBN_DBLCLK) {


### PR DESCRIPTION
- どの警告も致命的ではない、fall throughは偶然問題が出ない状態だった。
- warning: this statement may fall through [-Wimplicit-fallthrough=]
- warning: variable 'r' set but not used [-Wunused-but-set-variable=]
- warning: 'void* calloc(size_t, size_t)' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]