### PR TITLE
マクロの待ちに使用するAPIを変更して送信遅延を解消 #1290

### DIFF
--- a/doc/en/html/about/history.html
+++ b/doc/en/html/about/history.html
@@ -133,6 +133,12 @@
         This bug was introduced in 5.5.1.
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1459" target="_blank">issue #1459</a>)
       </li>
+      <li>
+        Fixed an issue where macro response could be delayed by a wait in the receive polling loop.
+        This bug was introduced in version 4.103.
+        See <a href="../macro/appendixes/speed.html">MACRO execution speed</a>.
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1290" target="_blank">issue #1290</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/en/html/macro/appendixes/index.html
+++ b/doc/en/html/macro/appendixes/index.html
@@ -17,6 +17,7 @@
  <li><a href="negative.html">Note on negative integer constants</a></li>
  <li><a href="disconnecttiming.html">NOTICE: Immediately re-connect the server after disconnection</a></li>
  <li><a href="ascii.html">ASCII code table</a></li>
+ <li><a href="speed.html">MACRO execution speed</a></li>
  <li><a href="../../reference/RE.txt">Oniguruma Regular Expressions</a></li>
 </ul>
 

--- a/doc/en/html/macro/appendixes/speed.html
+++ b/doc/en/html/macro/appendixes/speed.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+  "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<title>MACRO execution speed</title>
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="stylesheet" href="../../style.css" type="text/css">
+</head>
+<body>
+
+<h1>MACRO execution speed</h1>
+
+<p>
+  The macro receive wait is message driven. Sending a string, receiving and
+  checking the response, and sending the next string are performed without
+  extra wait time with the default settings.
+</p>
+
+<p>
+  The BoostTime entry in the Macro section of TERATERM.INI adjusts the
+  balance between macro execution speed and CPU load while waiting.
+  The unit is ms.
+</p>
+
+<p>
+  When the default or 0 is specified, the macro waits in a message driven
+  manner. Receiving data generates a message, so it is processed
+  immediately without wait time. When no message arrives, the state is
+  checked after waiting up to 1ms. Due to the timer resolution, this wait
+  can actually be up to about 15.6ms.
+</p>
+
+<p>
+  When a value of 1 or more is specified, no wait time is inserted for the
+  specified time after the last command execution. One CPU core is fully
+  occupied during this time. After the specified time has passed, the macro
+  waits in a message driven manner. Receiving data generates a message, so
+  it is processed immediately without wait time. When no message arrives,
+  the state is checked after waiting up to 2ms. Due to the timer
+  resolution, this wait can actually be up to about 15.6ms.
+</p>
+
+To set 500ms:
+<pre>
+[Macro]
+BoostTime=500
+</pre>
+
+<p>
+  When BoostTime is omitted, it is the same as specifying 0.
+</p>
+
+</body>
+</html>

--- a/doc/en/html/setup/teraterm-ini.html
+++ b/doc/en/html/setup/teraterm-ini.html
@@ -1770,6 +1770,23 @@ list3=3rd item
 	</tr>
 </table>
 
+<h2 id="Macro"><a href="../macro/appendixes/speed.html">Macro</a></h2>
+
+<table border="1">
+	<tr>
+		<th>item</th>
+		<th style="width:250px;">Default of setup file</th>
+		<th style="width:250px;">Default of program</th>
+		<th>Note</th>
+	</tr>
+	<tr>
+		<td>BoostTime</td>
+		<td style="width:250px;">0</td>
+		<td style="width:250px;">&lt;-</td>
+		<td>Unit is ms</td>
+	</tr>
+</table>
+
 <h2>TTSSH</h2>
 
 <table border="1">

--- a/doc/en/teraterm.hhc
+++ b/doc/en/teraterm.hhc
@@ -2040,6 +2040,11 @@
 				<param name="ImageNumber" value="11">
 				</OBJECT>
 			<LI> <OBJECT type="text/sitemap">
+				<param name="Name" value="MACRO execution speed">
+				<param name="Local" value="html\macro\appendixes\speed.html">
+				<param name="ImageNumber" value="11">
+				</OBJECT>
+			<LI> <OBJECT type="text/sitemap">
 				<param name="Name" value="Oniguruma Regular Expressions">
 				<param name="Local" value="html\reference\RE.txt">
 				<param name="ImageNumber" value="11">

--- a/doc/ja/html/about/history.html
+++ b/doc/ja/html/about/history.html
@@ -132,6 +132,12 @@
         5.5.1 からの不具合。
         (<a href="https://github.com/TeraTermProject/teraterm/issues/1459" target="_blank">issue #1459</a>)
       </li>
+      <li>
+        マクロの受信待ちに待ち時間が入り、応答が遅くなることがある不具合を修正した。
+        4.103 からの不具合。
+        <a href="../macro/appendixes/speed.html">MACROの実行速度について</a>も参照。
+        (<a href="https://github.com/TeraTermProject/teraterm/issues/1290" target="_blank">issue #1290</a>)
+      </li>
     </ul>
   </li>
 

--- a/doc/ja/html/macro/appendixes/index.html
+++ b/doc/ja/html/macro/appendixes/index.html
@@ -17,6 +17,7 @@
  <li><a href="negative.html">負の整数定数についての注意</a></li>
  <li><a href="disconnecttiming.html">切断後すぐに接続する場合の注意点</a></li>
  <li><a href="ascii.html">ASCII コード表</a></li>
+ <li><a href="speed.html">MACROの実行速度について</a></li>
  <li><a href="../../reference/RE.txt">鬼車正規表現</a></li>
 </ul>
 

--- a/doc/ja/html/macro/appendixes/speed.html
+++ b/doc/ja/html/macro/appendixes/speed.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+  "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS">
+<title>MACROの実行速度について</title>
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="stylesheet" href="../../style.css" type="text/css">
+</head>
+<body>
+
+<h1>MACROの実行速度について</h1>
+
+<p>
+  マクロの受信待ちはメッセージ駆動で動作しており、
+  文字列を送信、応答を受信して判定、次の文字列を送信、といった動作は、
+  デフォルト設定のままで余分な待ち時間なしに行うことができます。
+</p>
+
+<p>
+  TERATERM.INIのMacroセクションのBoostTimeで、
+  マクロの実行速度と待機中のCPU負荷のバランスを調整することができます。
+  単位はmsです。
+</p>
+
+<p>
+  デフォルト(未設定)又は0を指定した場合、ウィンドウメッセージが来るまで待機します。
+  データを受信するとメッセージが発生するので、待ち時間なしですぐに処理されます。
+  メッセージが来ない場合は最大1ms待ってから状態を確認します。
+  この待ち時間はタイマ分解能により実際は最大15.6ms程度になることがあります。
+</p>
+
+<p>
+  1以上の値を設定した場合、最後に命令を実行してから指定時間の間は、
+  待ち時間なしの状態となります。この間はCPUを1コア占有します。
+  指定時間を過ぎるとメッセージ駆動の待機となります。
+  データを受信するとメッセージが発生するので、待ち時間なしですぐに処理されます。
+  メッセージが来ない場合は最大2ms待ってから状態を確認します。
+  この待ち時間はタイマ分解能により実際は最大15.6ms程度になることがあります。
+</p>
+
+500msに設定する場合
+<pre>
+[Macro]
+BoostTime=500
+</pre>
+
+<p>
+  BoostTimeを省略した場合は、0を指定した場合と同じです。
+</p>
+
+</body>
+</html>

--- a/doc/ja/html/setup/teraterm-ini.html
+++ b/doc/ja/html/setup/teraterm-ini.html
@@ -1770,6 +1770,23 @@ list3=3rd item
 	</tr>
 </table>
 
+<h2 id="Macro"><a href="../macro/appendixes/speed.html">Macro</a></h2>
+
+<table border="1">
+	<tr>
+		<th>項目</th>
+		<th style="width:250px;">INIデフォルト</th>
+		<th style="width:250px;">プログラムデフォルト</th>
+		<th>備考</th>
+	</tr>
+	<tr>
+		<td>BoostTime</td>
+		<td style="width:250px;">0</td>
+		<td style="width:250px;">&lt;-</td>
+		<td>単位はms</td>
+	</tr>
+</table>
+
 <h2>TTSSH</h2>
 
 <table border="1">

--- a/doc/ja/teraterm.hhc
+++ b/doc/ja/teraterm.hhc
@@ -2063,6 +2063,11 @@
 				<param name="ImageNumber" value="11">
 				</OBJECT>
 			<LI> <OBJECT type="text/sitemap">
+				<param name="Name" value="MACRO‚ÌŽÀs‘¬“x‚É‚Â‚¢‚Ä">
+				<param name="Local" value="html\macro\appendixes\speed.html">
+				<param name="ImageNumber" value="11">
+				</OBJECT>
+			<LI> <OBJECT type="text/sitemap">
 				<param name="Name" value="‹SŽÔ ³‹K•\Œ»">
 				<param name="Local" value="html\reference\RE.txt">
 				<param name="ImageNumber" value="11">

--- a/teraterm/ttpmacro/ttmacro.cpp
+++ b/teraterm/ttpmacro/ttmacro.cpp
@@ -60,6 +60,7 @@ wchar_t *UILanguageFileW;
 static wchar_t *SetupFNameW;
 static HWND CtrlWnd;
 static HINSTANCE hInst;
+static DWORD BoostTimeMs;
 
 static BOOL Busy;
 static CCtrlWindow *pCCtrlWindow;
@@ -106,6 +107,13 @@ static void init()
 	GetI18nLogfontW(L"Tera Term", L"DlgFont", &logfont, 0, SetupFNameW);
 	SetDialogFont(logfont.lfFaceName, logfont.lfHeight, logfont.lfCharSet,
 				  UILanguageFileW, "Tera Term", "DLG_SYSTEM_FONT");
+
+	int boost_time = (int)GetPrivateProfileIntW(L"Macro", L"BoostTime", 0, SetupFNameW);
+	if (boost_time < 0) {
+		// マイナスの時は 0 として扱う
+		boost_time = 0;
+	}
+	BoostTimeMs = (DWORD)boost_time;
 }
 
 // TTMACRO main engine
@@ -133,7 +141,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 {
 	hInst = hInstance;
 	LONG lCount = 0;
-	DWORD SleepTick = 1;
 
 #ifdef _DEBUG
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
@@ -160,6 +167,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 
 	// message pump
 	MSG msg;
+	DWORD idle_enter_tick = GetTickCount();
+	BOOL sleep_enable = FALSE;
 	for (;;) {
 		// Windowsのメッセージがない場合のループ
 		for(;;) {
@@ -170,15 +179,28 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst,
 
 			if (!OnIdle(lCount)) {
 				// idle不要
-				if (SleepTick < 500) {	// 最大 501ms未満
-					SleepTick += 2;
+				if (BoostTimeMs == 0) {
+					// メッセージが来た時、即時に復帰する
+					// メッセージが来ない時、最大 1ms 待ってポーリングに戻る
+					MsgWaitForMultipleObjects(0, NULL, FALSE, 1, QS_ALLINPUT);
+				} else {
+					if (!sleep_enable) {
+						if (GetTickCount() - idle_enter_tick > BoostTimeMs) {
+							// idle不要時間がある程度継続したら、待ち時間を入れる
+							sleep_enable = TRUE;
+						}
+					}
+					if (sleep_enable) {
+						// メッセージが来た時、即時に復帰する
+						// メッセージが来ない時、最大 2ms 待ってポーリングに戻る
+						MsgWaitForMultipleObjects(0, NULL, FALSE, 2, QS_ALLINPUT);
+					}
 				}
 				lCount = 0;
-				Sleep(SleepTick);
 			} else {
 				// 要idle
-				SleepTick = 0;
-				lCount++;
+				idle_enter_tick = GetTickCount();
+				sleep_enable = FALSE;
 			}
 		}
 


### PR DESCRIPTION
- Sleep() を MsgWaitForMultipleObjects() 変更した
- MFC依存をなくしたときウィンドウメッセージを受信していないとき、
  - Sleep()時間が500msまで伸び、受信検出がその分遅れていた
  - 5a797287d9dd6ee96679598a31297735dd6d473b
- 受信データは DDE のウィンドウメッセージで届く
- MsgWaitForMultipleObjects() でウィンドウメッセージを待つよう変更した
  - ウィンドウメッセージを受信又は指定時間待った後returnするAPI
  - 従来より低負荷かつ応答性が良くなる
- TERATERM.INIのMacroセクションのBoostTime
  - MsgWaitForMultipleObjects()の待ち時間指定
  - 未設定(デフォルト=0)時、1msの待ち時間
  - 指定時、指定時間待ち時間なしでウィンドウメッセージをチェック 移行は2msの待ち時間
  - 待ち時間はタイマーの分解能から最大15.6ms程度になる