### PR TITLE
x64で動作するよう修正 #947

### DIFF
--- a/ttssh2/ttxssh/key.c
+++ b/ttssh2/ttxssh/key.c
@@ -468,7 +468,7 @@ static int ssh_ed25519_verify(Key *key, unsigned char *signature, unsigned int s
 	buffer_t *b = NULL;
 	char *ktype = NULL;
 	unsigned char *sigblob = NULL, *sm = NULL, *m = NULL;
-	unsigned int len;
+	size_t len;
 	unsigned long long smlen, mlen;
 	int rlen, ret, r = SSH_ERR_INTERNAL_ERROR;
 
@@ -1354,7 +1354,7 @@ Key *key_from_blob(char *data, int blen)
 {
 	buffer_t *b = NULL;
 	char *ktype = NULL;
-	int len;
+	size_t len;
 	RSA *rsa = NULL;
 	DSA *dsa = NULL;
 	EC_KEY *ecdsa = NULL;
@@ -1980,7 +1980,7 @@ Key *key_private_deserialize(buffer_t *blob)
 	int success = 0;
 	char *type_name = NULL;
 	Key *k = NULL;
-	unsigned int pklen, sklen;
+	size_t pklen, sklen;
 	int type;
 	BIGNUM *e, *n, *d, *dmp1, *dmq1, *iqmp, *p, *q;
 	BIGNUM *g, *pub_key, *priv_key;
@@ -2494,7 +2494,6 @@ static void client_global_hostkeys_private_confirm(PTInstVar pvar, int type, u_i
 	buffer_t *bsig = NULL;
 	char *cp, *sig;
 	size_t i, ndone, siglen;
-	int siglen_i;
 	int ret;
 
 	data = pvar->ssh_state.payload;
@@ -2549,11 +2548,10 @@ static void client_global_hostkeys_private_confirm(PTInstVar pvar, int type, u_i
 		free(blob);
 		blob = NULL;
 
-		if (buffer_get_string(bsig, &sig, &siglen_i) != 0) {
+		if (buffer_get_string(bsig, &sig, &siglen) != 0) {
 			logprintf(LOG_LEVEL_FATAL, "buffer put error");
 			goto error;
 		}
-		siglen = siglen_i;
 		// 手抜き。hostkey algorithm を使うのは RSA の時のみなので、
 		// とりあえず KEY_ALGO_RSA を指定しておく。
 		ret = key_verify(ctx->keys[i], sig, siglen, buffer_ptr(b), buffer_len(b), KEY_ALGO_RSA);
@@ -2593,10 +2591,11 @@ int update_client_input_hostkeys(PTInstVar pvar, char *dataptr, int datalen)
 {
 	int success = 1;  // OpenSSH 6.8の実装では、常に成功で返すようになっているため、
 	                  // それに合わせて Tera Term でも成功と返すことにする。
-	int len;
+	size_t len;
 	size_t i;
 	char *cp, *fp;
 	unsigned char *blob = NULL;
+	int bloblen;
 	buffer_t *b = NULL;
 	struct hostkeys_update_ctx *ctx = NULL;
 	Key *key = NULL, **tmp;
@@ -2628,9 +2627,9 @@ int update_client_input_hostkeys(PTInstVar pvar, char *dataptr, int datalen)
 			logprintf(LOG_LEVEL_FATAL, "buffer put error");
 			goto error;
 		}
-		key = key_from_blob(blob, len);
+		key = key_from_blob(blob, (int)len);
 		if (key == NULL) {
-			logprintf(LOG_LEVEL_ERROR, "Not found host key into blob %p (%d)", blob, len);
+			logprintf(LOG_LEVEL_ERROR, "Not found host key into blob %p (%d)", blob, (int)len);
 			goto error;
 		}
 		free(blob);
@@ -2710,8 +2709,8 @@ int update_client_input_hostkeys(PTInstVar pvar, char *dataptr, int datalen)
 		for (i = 0; i < ctx->nkeys; i++) {
 			if (ctx->keys_seen[i])
 				continue;
-			if (key_to_blob(ctx->keys[i], (char **)&blob, &len)  != 0 ||
-			    buffer_put_string(b, blob, len) != 0) {
+			if (key_to_blob(ctx->keys[i], (char **)&blob, &bloblen)  != 0 ||
+			    buffer_put_string(b, blob, bloblen) != 0) {
 				logprintf(LOG_LEVEL_FATAL, "buffer put error");
 				goto error;
 			}
@@ -2720,7 +2719,7 @@ int update_client_input_hostkeys(PTInstVar pvar, char *dataptr, int datalen)
 		}
 
 		len = buffer_len(b);
-		outmsg = begin_send_packet(pvar, SSH2_MSG_GLOBAL_REQUEST, len);
+		outmsg = begin_send_packet(pvar, SSH2_MSG_GLOBAL_REQUEST, (int)len);
 		memcpy(outmsg, buffer_ptr(b), len);
 		finish_send_packet(pvar);
 

--- a/ttssh2/ttxssh/keyfiles.c
+++ b/ttssh2/ttxssh/keyfiles.c
@@ -397,7 +397,8 @@ static Key *read_SSH2_private2_key(PTInstVar pvar,
 	unsigned char buf[1024];
 	unsigned char *cp, last, pad;
 	char *ciphername = NULL, *kdfname = NULL, *kdfp = NULL, *key = NULL, *salt = NULL, *comment = NULL;
-	unsigned int len, klen, nkeys, blocksize, keylen, ivlen, slen, rounds;
+	unsigned int len, nkeys, blocksize, keylen, ivlen, rounds;
+	size_t klen, publen, slen;
 	unsigned int check1, check2, m1len, m2len;
 	int dlen, i;
 	const struct ssh2cipher *cipher;
@@ -556,7 +557,7 @@ static Key *read_SSH2_private2_key(PTInstVar pvar,
 	}
 
 	/* pubkey */
-	if (buffer_get_string(copy_consumed, &cp, &len) != 0) {
+	if (buffer_get_string(copy_consumed, &cp, &publen) != 0) {
 		logprintf(LOG_LEVEL_ERROR, "%s: buffer put error", __FUNCTION__);
 		goto error;
 	}
@@ -1383,7 +1384,7 @@ ecdsa_error:
 	case KEY_ED25519:
 	{
 		char *pubkey_type;
-		unsigned int pklen, sklen;
+		size_t pklen, sklen;
 		char *sk;
 
 		if (buffer_get_string(public_blob, &pubkey_type, NULL) != 0) {

--- a/ttssh2/ttxssh/ssh.c
+++ b/ttssh2/ttxssh/ssh.c
@@ -8119,6 +8119,7 @@ BOOL handle_SSH2_userauth_inforeq(PTInstVar pvar)
 	char *prompt = NULL;
 	int prompt_len = 0;
 	char *prompt_disp = NULL;
+	size_t prompt_disp_len = 0;
 
 	logputs(LOG_LEVEL_VERBOSE, "SSH2_MSG_USERAUTH_INFO_REQUEST was received.");
 
@@ -8216,7 +8217,7 @@ BOOL handle_SSH2_userauth_inforeq(PTInstVar pvar)
 		buffer_rewind(pvar->userauth_inforeq_prompts);
 
 		// 1個目のプロンプトでダイアログを表示
-		if (buffer_get_string(pvar->userauth_inforeq_prompts, &prompt_disp, &prompt_len) != 0) {
+		if (buffer_get_string(pvar->userauth_inforeq_prompts, &prompt_disp, &prompt_disp_len) != 0) {
 			logprintf(LOG_LEVEL_ERROR, "%s: buffer put error", __FUNCTION__);
 			goto err;
 		}
@@ -8228,7 +8229,7 @@ BOOL handle_SSH2_userauth_inforeq(PTInstVar pvar)
 
 		// keyboard-interactive method
 		if (pvar->auth_state.cur_cred.method == SSH_AUTH_TIS) {
-			AUTH_set_TIS_mode(pvar, prompt_disp, prompt_len, echo);
+			AUTH_set_TIS_mode(pvar, prompt_disp, (int)prompt_disp_len, echo);
 			AUTH_advance_to_next_cred(pvar);
 			pvar->ssh_state.status_flags &= ~STATUS_DONT_SEND_CREDENTIALS;
 			//try_send_credentials(pvar);
@@ -8256,7 +8257,7 @@ void SSH2_send_userauth_infores(PTInstVar pvar)
 	int echo;
 	char *s;
 	char *prompt_disp = NULL;
-	int prompt_len = 0;
+	size_t prompt_len = 0;
 	unsigned char *outmsg;
 
 	if (pvar->userauth_inforeq_num) {
@@ -8283,7 +8284,7 @@ void SSH2_send_userauth_infores(PTInstVar pvar)
 
 		// keyboard-interactive method
 		if (pvar->auth_state.cur_cred.method == SSH_AUTH_TIS) {
-			AUTH_set_TIS_mode(pvar, prompt_disp, prompt_len, echo);
+			AUTH_set_TIS_mode(pvar, prompt_disp, (int)prompt_len, echo);
 			AUTH_advance_to_next_cred(pvar);
 			pvar->ssh_state.status_flags &= ~STATUS_DONT_SEND_CREDENTIALS;
 			//try_send_credentials(pvar);


### PR DESCRIPTION
- int/unsigned intとsize_tの変数サイズがx64の時は異なっている
  - 次のような警告が出るとき問題が出る
  - warning C4133: '関数': 'unsigned int *' と 'size_t *' の間で型に互換性がありません。
- 変数の型を修正した